### PR TITLE
Query job status method on Web APi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ Accept more formats as inputs
 Fix the loss of optional_callback
 Ensure that we allow nil inputs or empty hashes for options and id_info
 Confirm the signature when querying the job status
+Add a Utilities class with get_job_status that we use internally to expose a public get_job_status method on WebApi

--- a/README.md
+++ b/README.md
@@ -2,24 +2,33 @@
 
 The official Smile Identity gem exposes two classes namely, the Web API and Signature class.
 
-The Web API allows you as the Partner to validate a user’s identity against the relevant Identity Authorities/Third Party databases that Smile Identity has access to using ID information provided by your customer/user (including photo for compare).
+The **Web API Class** allows you as the Partner to validate a user’s identity against the relevant Identity Authorities/Third Party databases that Smile Identity has access to using ID information provided by your customer/user (including photo for compare). It has the following public methods:
+- submit_job
+- get_job_status
 
-The Signature class allows you as the Partner to generate a sec key to interact with our servers.
+The **Signature Class** allows you as the Partner to generate a sec key to interact with our servers. It has the following public methods:
+- generate_sec_key
+- confirm_sec_key
+
+<!-- The **Utilities Class** allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
+- get_job_status -->
 
 ## Documentation
 
 This gem requires specific input parameters, for more detail on these parameters please refer to our [documentation for Web API](https://docs-smileid.herokuapp.com/docs#web-api-introduction).
 
-Please note that you will have to be a Smile Identity Partner to be able to query our services.
+Please note that you will have to be a Smile Identity Partner to be able to query our services. You can sign up on the [Portal](https://test-smileid.herokuapp.com/signup?products[]=1-IDVALIDATION&products[]=2-AUTHENTICATION).
 
-## Usage
+## Installation
+
+View the package on [Rubygems](https://rubygems.org/gems/smile-identity-core).
 
 Add this line to your application's Gemfile:
 
 ```ruby
 gem 'smile-identity-core'
 ```
-and
+and require the package:
 
 ```ruby
 require 'smile-identity-core'
@@ -31,30 +40,20 @@ Or install it to your system as:
   $ gem install smile-identity-core
 ```
 
-#### Calculating your Signature
+You now may use the classes as follows:
 
-```
-$ connection = SmileIdentityCore::Signature.new(partner_id, api_key)
+#### Web Api Class
 
-$ sec_key = connection.generate_sec_key(timestamp)
-where timestamp is optional
-
-```
-
-The response will be a hash:
-
-```
-{
-  :sec_key=> "<the generated sec key>",
- :timestamp=> 1563283420
-}
-```
-
-#### Web api
+##### submit_job method
 ```
 $ connection = SmileIdentityCore::WebApi.new(partner_id, default_callback, api_key, sid_server)
 
 $ response = connection.submit_job(partner_params, images, id_info, options)
+```
+
+Please note that if you do not need to pass through id_info or options, you may omit calling those class and send through nil in submit_job, as follows:
+```
+String response = connection.submit_job(partner_params, images, nil, nil);
 ```
 
 The response will be nil if you chose to set return_job_status to false, however if you have set return_job_status to true then you will receive a response like below:
@@ -99,6 +98,69 @@ You can also view your response asynchronously at the callback that you have set
   "ConfidenceValue": "100.000000",
   "IsMachineResult": "true"
 }
+```
+
+##### get_job_status method
+Sometimes, you may want to get a particular job status at a later time. You may use the get_job_status function to do this:
+
+You will already have your Web Api class initialised as follows:
+```ruby
+  connection = SmileIdentityCore::WebApi.new(partner_id, default_callback, api_key, sid_server)
+```
+
+Thereafter, simply call get_job_status with the correct parameters:
+```ruby
+  response = connection.get_job_status(partner_params, options)
+
+  where options is {return_history: true | false, return_image_links: true | false}
+```
+
+Please note that if you do not need to pass through options if you will not be using them, you may omit pass through an empty hash or nil instead:
+```ruby
+response = connection.get_job_status(partner_params, nil);
+```
+
+#### Signature Class
+
+##### generate_sec_key method
+
+```
+$ connection = SmileIdentityCore::Signature.new(partner_id, api_key)
+
+$ sec_key = connection.generate_sec_key(timestamp)
+where timestamp is optional
+
+```
+
+The response will be a hash:
+
+```
+{
+  :sec_key=> "<the generated sec key>",
+ :timestamp=> 1563283420
+}
+```
+
+##### confirm_sec_key method
+
+You can also confirm the signature that you receive when you interacting with our servers, simply use the confirm_sec_key method which returns a boolean:
+
+```ruby
+$ connection = SmileIdentityCore::Signature.new(partner_id, api_key)
+$ sec_key = connection.confirm_sec_key(sec_key, timestamp)
+```
+
+<!-- #### Utilities Class
+
+You may want to receive more information about a job. This is built into Web Api if you choose to set return_job_status as true in the options hash. However, you also have the option to build the functionality yourself by using the Utilities class. Please note that if you are querying a job immediately after submitting it, you will need to poll it for the duration of the job.
+
+```java
+
+
+utilities_connection = SmileIdentityCore::Utilities.new('partner_id', 'api_key' , sid_server)
+
+utilities_connection.get_job_status('user_id', 'job_id', options)
+where options is {return_history: true | false, return_image_links: true | false}
 ```
 
 ## Development

--- a/lib/smile-identity-core.rb
+++ b/lib/smile-identity-core.rb
@@ -1,6 +1,7 @@
 require "smile-identity-core/version"
 require "smile-identity-core/web_api.rb"
 require "smile-identity-core/signature.rb"
+require "smile-identity-core/utilities.rb"
 
 module SmileIdentityCore
   class Error < StandardError; end

--- a/lib/smile-identity-core/utilities.rb
+++ b/lib/smile-identity-core/utilities.rb
@@ -39,6 +39,7 @@ module SmileIdentityCore
       request.on_complete do |response|
         begin
           body = JSON.parse(response.body)
+
           valid = @signature_connection.confirm_sec_key(body['timestamp'], body['signature'])
 
           if(!valid)
@@ -54,7 +55,6 @@ module SmileIdentityCore
 
       request.run
     end
-
 
     def configure_job_query(user_id, job_id, return_image_links, return_history)
       return {

--- a/lib/smile-identity-core/utilities.rb
+++ b/lib/smile-identity-core/utilities.rb
@@ -22,7 +22,6 @@ module SmileIdentityCore
     def get_job_status(user_id, job_id, return_image_links, return_history)
       @timestamp = Time.now.to_i
       return query_job_status(user_id, job_id, return_image_links, return_history)
-
     end
 
     private
@@ -39,18 +38,18 @@ module SmileIdentityCore
 
       request.on_complete do |response|
         begin
-          valid = @signature_connection.confirm_sec_key(status_body['timestamp'], status_body['signature'])
+          body = JSON.parse(response.body)
+          valid = @signature_connection.confirm_sec_key(body['timestamp'], body['signature'])
 
           if(!valid)
             raise "Unable to confirm validity of the job_status response"
           end
 
-          return JSON.parse(response.body)
+          return body
         rescue => e
           puts e.message
           puts e.backtrace
         end
-
       end
 
       request.run

--- a/lib/smile-identity-core/utilities.rb
+++ b/lib/smile-identity-core/utilities.rb
@@ -21,6 +21,13 @@ module SmileIdentityCore
 
     def get_job_status(user_id, job_id, options = {})
 
+      if(options.nil? || options.empty?)
+        options = {
+          return_history: false,
+          return_job_status: false
+        }
+      end
+
       @timestamp = Time.now.to_i
       return query_job_status(user_id, job_id, symbolize_keys(options))
     end

--- a/lib/smile-identity-core/utilities.rb
+++ b/lib/smile-identity-core/utilities.rb
@@ -1,0 +1,73 @@
+module SmileIdentityCore
+  class Utilities
+
+    def initialize(partner_id, api_key, sid_server)
+      @partner_id = partner_id.to_s
+      @api_key = api_key
+
+      if !(sid_server =~ URI::regexp)
+        sid_server_mapping = {
+          0 => 'https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test',
+          1 => 'https://la7am6gdm8.execute-api.us-west-2.amazonaws.com/prod'
+        }
+        @url = sid_server_mapping[sid_server.to_i]
+      else
+        @url = sid_server
+      end
+
+      @signature_connection = SmileIdentityCore::Signature.new(@partner_id, @api_key)
+
+    end
+
+    def get_job_status(user_id, job_id, return_image_links, return_history)
+      @timestamp = Time.now.to_i
+      return query_job_status(user_id, job_id, return_image_links, return_history)
+
+    end
+
+    private
+
+    def query_job_status(user_id, job_id, return_image_links, return_history)
+      url = "#{@url}/job_status"
+
+      request = Typhoeus::Request.new(
+        url,
+        headers: {'Content-Type': 'application/json', 'Accept': 'application/json'},
+        method: :post,
+        body: configure_job_query(user_id, job_id, return_image_links, return_history)
+      )
+
+      request.on_complete do |response|
+        begin
+          valid = @signature_connection.confirm_sec_key(status_body['timestamp'], status_body['signature'])
+
+          if(!valid)
+            raise "Unable to confirm validity of the job_status response"
+          end
+
+          return JSON.parse(response.body)
+        rescue => e
+          puts e.message
+          puts e.backtrace
+        end
+
+      end
+
+      request.run
+    end
+
+
+    def configure_job_query(user_id, job_id, return_image_links, return_history)
+      return {
+        sec_key: @signature_connection.generate_sec_key(@timestamp)[:sec_key],
+        timestamp: @timestamp,
+        user_id: user_id,
+        job_id: job_id,
+        partner_id: @partner_id,
+        image_links: return_image_links,
+        history: return_history
+      }.to_json
+    end
+
+  end
+end

--- a/lib/smile-identity-core/utilities.rb
+++ b/lib/smile-identity-core/utilities.rb
@@ -60,8 +60,7 @@ module SmileIdentityCore
 
           return body
         rescue => e
-          puts e.message
-          puts e.backtrace
+          raise e
         end
       end
 

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -48,6 +48,17 @@ module SmileIdentityCore
       return setup_requests
     end
 
+    def get_job_status(partner_params, options)
+      partner_params = symbolize_keys partner_params
+      @timestamp = Time.now.to_i
+
+      user_id = partner_params[:user_id]
+      job_id = partner_params[:job_id]
+
+      utilities = SmileIdentityCore::Utilities.new(@partner_id, @api_key, @sid_server)
+      return utilities.get_job_status(user_id, job_id, options);
+    end
+
     def partner_params=(partner_params)
       if partner_params == nil
         raise ArgumentError.new('Please ensure that you send through partner params')

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -120,7 +120,7 @@ module SmileIdentityCore
         end
       end
 
-      if updated_id_info[:country].upcase == 'NG' && ['PASSPORT', 'VOTER_ID', 'DRIVERS_LICENSE', 'NATIONAL_ID', 'TIN', 'CAC'].include?(updated_id_info[:id_type].upcase) && (!updated_id_info[:dob] || updated_id_info[:dob].empty? || updated_id_info[:dob].nil?)
+      if updated_id_info[:country] && updated_id_info[:country].upcase == 'NG' && ['PASSPORT', 'VOTER_ID', 'DRIVERS_LICENSE', 'NATIONAL_ID', 'TIN', 'CAC'].include?(updated_id_info[:id_type].upcase) && (!updated_id_info[:dob] || updated_id_info[:dob].empty? || updated_id_info[:dob].nil?)
         raise ArgumentError.new("The ID type #{updated_id_info[:id_type]} for #{updated_id_info[:country]} requires a valid dob paramater.")
       end
 

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -92,7 +92,7 @@ module SmileIdentityCore
       end
 
       # if it doesnt exist, set it false
-      if(!updated_id_info.key?(:entered) || id_info[:entered].empty? )
+      if(!updated_id_info.key?(:entered) || id_info[:entered].empty?)
         updated_id_info[:entered] = "false"
       end
 
@@ -107,6 +107,10 @@ module SmileIdentityCore
             raise ArgumentError.new("Please make sure that #{key.to_s} is included in the id_info")
           end
         end
+      end
+
+      if updated_id_info[:country].upcase == 'NG' && ['PASSPORT', 'VOTER_ID', 'DRIVERS_LICENSE', 'NATIONAL_ID', 'TIN', 'CAC'].include?(updated_id_info[:id_type].upcase) && (!updated_id_info[:dob] || updated_id_info[:dob].empty? || updated_id_info[:dob].nil?)
+        raise ArgumentError.new("The ID type #{updated_id_info[:id_type]} for #{updated_id_info[:country]} requires a valid dob paramater.")
       end
 
       @id_info = updated_id_info

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -337,7 +337,7 @@ module SmileIdentityCore
       counter < 4 ? (sleep 2) : (sleep 6)
       counter += 1
 
-      response = @utilies_connection.get_job_status(@partner_params[:user_id], @partner_params[:job_id], @options[:return_image_links], @options[:return_history])
+      response = @utilies_connection.get_job_status(@partner_params[:user_id], @partner_params[:job_id], @options)
 
       if response && (response['job_complete'] == true || counter == 20)
         return response

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -178,7 +178,7 @@ module SmileIdentityCore
 
     def configure_prep_upload_json
 
-      body =  {
+      body = {
         file_name: 'selfie.zip',
         timestamp: @timestamp,
         sec_key: determine_sec_key,

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe SmileIdentityCore do
+  let (:partner_id) {1}
+  let (:sid_server) {0}
+  let (:rsa) { OpenSSL::PKey::RSA.new(1024) }
+  let (:api_key) {Base64.strict_encode64(rsa.public_key.to_pem)}
+  let (:connection) { SmileIdentityCore::Utilities.new(partner_id, api_key, sid_server)}
+  let(:timestamp) {Time.now.to_i}
+
+  describe '#initialize' do
+    it "receives the correct attributes and returns an instance" do
+      expect(SmileIdentityCore::Utilities).to receive(:new).with(partner_id, api_key, sid_server).and_return(connection)
+
+      connection = SmileIdentityCore::Utilities.new(partner_id, api_key, sid_server)
+    end
+
+    [:@partner_id, :@api_key].each do |instance_variable|
+      it "sets the #{instance_variable} instance variable" do
+        value = eval(instance_variable.slice(1..instance_variable.length-1))
+        expect(connection.instance_variable_get(instance_variable)).to eq(value.to_s)
+      end
+    end
+
+    it "sets the correct @url instance variable" do
+      expect(connection.instance_variable_get(:@url)).to eq('https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test')
+
+      connection = SmileIdentityCore::Utilities.new(partner_id, api_key, 'https://something34.api.us-west-2.amazonaws.com/something')
+      expect(connection.instance_variable_get(:@url)).to eq('https://something34.api.us-west-2.amazonaws.com/something')
+    end
+  end
+
+  describe '#query_job_status' do
+    let (:url) { 'https://some_server.com/dev01' }
+    let (:rsa) { OpenSSL::PKey::RSA.new(1024) }
+    let (:partner_id) { 1 }
+    let (:api_key) { Base64.strict_encode64(rsa.public_key.to_pem) }
+    let (:timestamp)   { Time.now.to_i }
+
+    before(:each) {
+      connection.instance_variable_set('@url', url )
+      connection.instance_variable_set('@api_key', api_key)
+      connection.instance_variable_set('@partner_id', partner_id)
+
+      hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp].join(":"))
+      @sec_key = [Base64.strict_encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
+    }
+
+    it 'returns the response if job_complete is true' do
+      body = {
+        timestamp: "#{timestamp}",
+        signature: "#{@sec_key}",
+        job_complete: true,
+        job_success: false,
+        code: "2302"
+      }.to_json
+
+      typhoeus_response = Typhoeus::Response.new(code: 200, body: body.to_s)
+      Typhoeus.stub(@url).and_return(typhoeus_response)
+
+      expect(connection.send(:query_job_status, '1', '1', {return_job_status: true, return_image_links: true})).to eq(JSON.load(body.to_s))
+    end
+
+  end
+
+  describe '#configure_job_query' do
+    it 'should set the correct keys on the payload' do
+      ['sec_key', 'timestamp', 'user_id', 'job_id', 'partner_id', 'image_links', 'history'].each do |key|
+        expect(JSON.parse(connection.send(:configure_job_query, 1, 2, {return_history: true, return_image_links: true}))).to have_key(key)
+      end
+    end
+  end
+
+end

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe SmileIdentityCore do
         connection = SmileIdentityCore::WebApi.new(partner_id, default_callback, api_key, sid_server)
       end
 
-      [:@partner_id, :@api_key].each do |instance_variable|
+      [:@partner_id, :@api_key, :@sid_server].each do |instance_variable|
         it "sets the #{instance_variable} instance variable" do
           value = eval(instance_variable.slice(1..instance_variable.length-1))
           expect(connection.instance_variable_get(instance_variable)).to eq(value)
@@ -660,14 +660,13 @@ RSpec.describe SmileIdentityCore do
         connection.instance_variable_set('@options', options)
         connection.instance_variable_set('@api_key', api_key)
         connection.instance_variable_set('@partner_id', partner_id)
+        connection.instance_variable_set('@utilies_connection', SmileIdentityCore::Utilities.new(partner_id, api_key, sid_server))
 
         hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp].join(":"))
         @sec_key = [Base64.strict_encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
       }
 
       it 'returns the response if job_complete is true' do
-
-
         body = {
           timestamp: "#{timestamp}",
           signature: "#{@sec_key}",


### PR DESCRIPTION
- Add a Utilities class with get_job_status that we use internally to expose a public get_job_status method on WebApi
- update readme 
- add some tests

![giphy (9)](https://user-images.githubusercontent.com/2786819/64346381-4cdb8180-cff2-11e9-85de-2287ba1cfe09.gif)
