### PR TITLE
Decode Keys Leniently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
-/.gem
+/*.gem
 
 # rspec failure tracking
 .rspec_status

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.gem
 
 # rspec failure tracking
 .rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@ Add a Utilities class with get_job_status that we use internally to expose a pub
 ## [0.2.2] - 2019-09-17
 ### Updated
 Add the language to the package information
+
+## [0.2.3] - 2019-09-17
+### Updated
+Lenient Decoding of the api key

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smile-identity-core (0.2.2)
+    smile-identity-core (0.2.3)
       rubyzip (~> 1.2, >= 1.2.3)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SmileIdentityCore
 
-The official Smile Identity gem exposes two classes namely, the Web API and Signature class.
+The official Smile Identity gem exposes three classes namely, the Web API and Signature class.
 
 The **Web API Class** allows you as the Partner to validate a user’s identity against the relevant Identity Authorities/Third Party databases that Smile Identity has access to using ID information provided by your customer/user (including photo for compare). It has the following public methods:
 - submit_job
@@ -10,8 +10,8 @@ The **Signature Class** allows you as the Partner to generate a sec key to inter
 - generate_sec_key
 - confirm_sec_key
 
-<!-- The **Utilities Class** allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
-- get_job_status -->
+The **Utilities Class** allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
+- get_job_status
 
 ## Documentation
 
@@ -150,7 +150,7 @@ $ connection = SmileIdentityCore::Signature.new(partner_id, api_key)
 $ sec_key = connection.confirm_sec_key(sec_key, timestamp)
 ```
 
-<!-- #### Utilities Class
+#### Utilities Class
 
 You may want to receive more information about a job. This is built into Web Api if you choose to set return_job_status as true in the options hash. However, you also have the option to build the functionality yourself by using the Utilities class. Please note that if you are querying a job immediately after submitting it, you will need to poll it for the duration of the job.
 
@@ -161,7 +161,7 @@ utilities_connection = SmileIdentityCore::Utilities.new('partner_id', 'api_key' 
 
 utilities_connection.get_job_status('user_id', 'job_id', options)
 where options is {return_history: true | false, return_image_links: true | false}
-``` -->
+```
 
 ## Development
 

--- a/lib/smile-identity-core/signature.rb
+++ b/lib/smile-identity-core/signature.rb
@@ -10,7 +10,7 @@ module SmileIdentityCore
       begin
         @timestamp = timestamp
 
-        hash_signature = Digest::SHA256.hexdigest([@partner_id, @timestamp].join(":"))
+        hash_signature = Digest::SHA256.hexdigest([@partner_id.to_i, @timestamp].join(":"))
         public_key = OpenSSL::PKey::RSA.new(Base64.decode64(@api_key))
         @sec_key = [Base64.strict_encode64(public_key.public_encrypt(hash_signature)), hash_signature].join('|')
 
@@ -25,7 +25,7 @@ module SmileIdentityCore
 
     def confirm_sec_key(timestamp, sec_key)
       begin
-        hash_signature = Digest::SHA256.hexdigest([@partner_id, timestamp].join(":"))
+        hash_signature = Digest::SHA256.hexdigest([@partner_id.to_i, timestamp].join(":"))
         encrypted = sec_key.split('|')[0]
 
         public_key = OpenSSL::PKey::RSA.new(Base64.decode64(@api_key))

--- a/lib/smile-identity-core/signature.rb
+++ b/lib/smile-identity-core/signature.rb
@@ -12,7 +12,7 @@ module SmileIdentityCore
 
         hash_signature = Digest::SHA256.hexdigest([@partner_id.to_i, @timestamp].join(":"))
         public_key = OpenSSL::PKey::RSA.new(Base64.decode64(@api_key))
-        @sec_key = [Base64.strict_encode64(public_key.public_encrypt(hash_signature)), hash_signature].join('|')
+        @sec_key = [Base64.encode64(public_key.public_encrypt(hash_signature)), hash_signature].join('|')
 
         return {
           sec_key: @sec_key,

--- a/lib/smile-identity-core/signature.rb
+++ b/lib/smile-identity-core/signature.rb
@@ -11,7 +11,7 @@ module SmileIdentityCore
         @timestamp = timestamp
 
         hash_signature = Digest::SHA256.hexdigest([@partner_id, @timestamp].join(":"))
-        public_key = OpenSSL::PKey::RSA.new(Base64.strict_decode64(@api_key))
+        public_key = OpenSSL::PKey::RSA.new(Base64.decode64(@api_key))
         @sec_key = [Base64.strict_encode64(public_key.public_encrypt(hash_signature)), hash_signature].join('|')
 
         return {
@@ -28,8 +28,8 @@ module SmileIdentityCore
         hash_signature = Digest::SHA256.hexdigest([@partner_id, timestamp].join(":"))
         encrypted = sec_key.split('|')[0]
 
-        public_key = OpenSSL::PKey::RSA.new(Base64.strict_decode64(@api_key))
-        decrypted = public_key.public_decrypt(Base64.strict_decode64(encrypted))
+        public_key = OpenSSL::PKey::RSA.new(Base64.decode64(@api_key))
+        decrypted = public_key.public_decrypt(Base64.decode64(encrypted))
 
         return decrypted == hash_signature
       rescue => e

--- a/lib/smile-identity-core/version.rb
+++ b/lib/smile-identity-core/version.rb
@@ -1,3 +1,3 @@
 module SmileIdentityCore
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/smile-identity-core/signature_spec.rb
+++ b/spec/smile-identity-core/signature_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe SmileIdentityCore do
   let (:partner_id) {1}
   let (:rsa) { OpenSSL::PKey::RSA.new(1024) }
-  let (:api_key) {Base64.strict_encode64(rsa.public_key.to_pem)}
+  let (:api_key) {Base64.encode64(rsa.public_key.to_pem)}
   let (:connection) { SmileIdentityCore::Signature.new(partner_id, api_key)}
 
   describe '#confirm_sec_key' do
@@ -30,7 +30,7 @@ RSpec.describe SmileIdentityCore do
     it 'should confirm the sec_key from the server' do
       timestamp = Time.now.to_i
       hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp].join(":"))
-      sec_key = [Base64.strict_encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
+      sec_key = [Base64.encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
 
       expect(connection.confirm_sec_key(timestamp, sec_key)).to eq(true)
     end

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe SmileIdentityCore do
   let (:partner_id) {1}
   let (:sid_server) {0}
   let (:rsa) { OpenSSL::PKey::RSA.new(1024) }
-  let (:api_key) {Base64.strict_encode64(rsa.public_key.to_pem)}
+  let (:api_key) {Base64.encode64(rsa.public_key.to_pem)}
   let (:connection) { SmileIdentityCore::Utilities.new(partner_id, api_key, sid_server)}
   let(:timestamp) {Time.now.to_i}
 
@@ -32,7 +32,7 @@ RSpec.describe SmileIdentityCore do
     let (:url) { 'https://some_server.com/dev01' }
     let (:rsa) { OpenSSL::PKey::RSA.new(1024) }
     let (:partner_id) { 1 }
-    let (:api_key) { Base64.strict_encode64(rsa.public_key.to_pem) }
+    let (:api_key) { Base64.encode64(rsa.public_key.to_pem) }
     let (:timestamp)   { Time.now.to_i }
 
     before(:each) {
@@ -41,7 +41,7 @@ RSpec.describe SmileIdentityCore do
       connection.instance_variable_set('@partner_id', partner_id)
 
       hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp].join(":"))
-      @sec_key = [Base64.strict_encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
+      @sec_key = [Base64.encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
     }
 
     it 'returns the response if job_complete is true' do

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe SmileIdentityCore do
 
   let (:partner_id) {'001'}
   let (:default_callback) {'www.default_callback.com'}
-  let (:api_key) {Base64.strict_encode64( OpenSSL::PKey::RSA.new(1024).public_key.to_pem)}
+  let (:api_key) {Base64.encode64( OpenSSL::PKey::RSA.new(1024).public_key.to_pem)}
   let (:sid_server) {0}
 
   let (:connection) {SmileIdentityCore::WebApi.new(partner_id, default_callback, api_key, sid_server)}
@@ -647,7 +647,7 @@ RSpec.describe SmileIdentityCore do
       let (:url) { 'https://some_server.com/dev01' }
       let (:rsa) { OpenSSL::PKey::RSA.new(1024) }
       let (:partner_id) { 1 }
-      let (:api_key) { Base64.strict_encode64(rsa.public_key.to_pem) }
+      let (:api_key) { Base64.encode64(rsa.public_key.to_pem) }
       let (:timestamp)   { Time.now.to_i }
 
       before(:each) {
@@ -663,7 +663,7 @@ RSpec.describe SmileIdentityCore do
         connection.instance_variable_set('@utilies_connection', SmileIdentityCore::Utilities.new(partner_id, api_key, sid_server))
 
         hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp].join(":"))
-        @sec_key = [Base64.strict_encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
+        @sec_key = [Base64.encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
       }
 
       it 'returns the response if job_complete is true' do


### PR DESCRIPTION
I was strict decoding the key which broke when the keys have a \n in them (this occurred for old keys in the portal system that were saved in the db with an \n)

![giphy (13)](https://user-images.githubusercontent.com/2786819/65052108-55c14100-d96a-11e9-8723-691fdcb58b77.gif)
