### PR TITLE
Finish the sec_key -> signature work

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     ffi (1.13.1)
-    json (2.2.0)
+    json (2.5.1)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -48,4 +48,4 @@ DEPENDENCIES
   smile-identity-core!
 
 BUNDLED WITH
-   2.0.2
+   2.2.6

--- a/lib/smile-identity-core/id_api.rb
+++ b/lib/smile-identity-core/id_api.rb
@@ -105,15 +105,15 @@ module SmileIdentityCore
         .to_json
     end
 
-    def request_security(timestamp = Time.now, use_legacy_sec_key: true)
+    def request_security(use_legacy_sec_key: true)
       if use_legacy_sec_key
-        @timestamp = timestamp.to_i
+        @timestamp = Time.now.to_i
         {
           sec_key: SmileIdentityCore::Signature.new(@partner_id, @api_key).generate_sec_key(@timestamp)[:sec_key],
           timestamp: @timestamp,
         }
       else
-        @timestamp = timestamp.to_s
+        @timestamp = Time.now.to_s
         {
           signature: SmileIdentityCore::Signature.new(@partner_id, @api_key).generate_signature(@timestamp)[:signature],
           timestamp: @timestamp,

--- a/lib/smile-identity-core/id_api.rb
+++ b/lib/smile-identity-core/id_api.rb
@@ -8,8 +8,8 @@ module SmileIdentityCore
       @sid_server = sid_server
       if !(sid_server =~ URI::regexp)
         sid_server_mapping = {
-          0 => 'https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test',
-          1 => 'https://la7am6gdm8.execute-api.us-west-2.amazonaws.com/prod'
+          0 => 'https://testapi.smileidentity.com/v1',
+          1 => 'https://api.smileidentity.com/v1',
         }
         @url = sid_server_mapping[sid_server.to_i]
       else

--- a/lib/smile-identity-core/id_api.rb
+++ b/lib/smile-identity-core/id_api.rb
@@ -77,7 +77,7 @@ module SmileIdentityCore
         url,
         method: 'POST',
         headers: {'Content-Type'=> "application/json"},
-        body: id_verification_request
+        body: configure_json
       )
 
       request.on_complete do |response|
@@ -96,7 +96,7 @@ module SmileIdentityCore
       request.run
     end
 
-    def id_verification_request
+    def configure_json
       request_security(use_legacy_sec_key: @use_legacy_sec_key)
         .merge(@id_info)
         .merge(

--- a/lib/smile-identity-core/signature.rb
+++ b/lib/smile-identity-core/signature.rb
@@ -23,6 +23,20 @@ module SmileIdentityCore
       end
     end
 
+    def confirm_sec_key(timestamp, sec_key)
+      begin
+        hash_signature = Digest::SHA256.hexdigest([@partner_id.to_i, timestamp].join(":"))
+        encrypted = sec_key.split('|')[0]
+
+        public_key = OpenSSL::PKey::RSA.new(Base64.decode64(@api_key))
+        decrypted = public_key.public_decrypt(Base64.decode64(encrypted))
+
+        return decrypted == hash_signature
+      rescue => e
+        raise e
+      end
+    end
+
     def generate_signature(timestamp=Time.now.to_s)
       hmac = OpenSSL::HMAC.new(@api_key, 'sha256')
       hmac.update(timestamp.to_s)
@@ -42,20 +56,6 @@ module SmileIdentityCore
       hmac.update("sid_request")
       signature = Base64.strict_encode64(hmac.digest())
       return signature == msg_signature
-    end
-
-    def confirm_sec_key(timestamp, sec_key)
-      begin
-        hash_signature = Digest::SHA256.hexdigest([@partner_id.to_i, timestamp].join(":"))
-        encrypted = sec_key.split('|')[0]
-
-        public_key = OpenSSL::PKey::RSA.new(Base64.decode64(@api_key))
-        decrypted = public_key.public_decrypt(Base64.decode64(encrypted))
-
-        return decrypted == hash_signature
-      rescue => e
-        raise e
-      end
     end
   end
 end

--- a/lib/smile-identity-core/signature.rb
+++ b/lib/smile-identity-core/signature.rb
@@ -50,12 +50,7 @@ module SmileIdentityCore
     end
 
     def confirm_signature(timestamp, msg_signature)
-      hmac = OpenSSL::HMAC.new(@api_key, 'sha256')
-      hmac.update(timestamp)
-      hmac.update(@partner_id)
-      hmac.update("sid_request")
-      signature = Base64.strict_encode64(hmac.digest())
-      return signature == msg_signature
+      generate_signature(timestamp)[:signature] == msg_signature
     end
   end
 end

--- a/lib/smile-identity-core/utilities.rb
+++ b/lib/smile-identity-core/utilities.rb
@@ -72,15 +72,15 @@ module SmileIdentityCore
       request.run
     end
 
-    def request_security(timestamp = Time.now, use_legacy_sec_key: true)
+    def request_security(use_legacy_sec_key: true)
       if use_legacy_sec_key
-        @timestamp = timestamp.to_i
+        @timestamp = Time.now.to_i
         {
           sec_key: @signature_connection.generate_sec_key(@timestamp)[:sec_key],
           timestamp: @timestamp,
         }
       else
-        @timestamp = timestamp.to_s
+        @timestamp = Time.now.to_s
         {
           signature: @signature_connection.generate_signature(@timestamp)[:signature],
           timestamp: @timestamp,

--- a/lib/smile-identity-core/utilities.rb
+++ b/lib/smile-identity-core/utilities.rb
@@ -7,8 +7,8 @@ module SmileIdentityCore
 
       if !(sid_server =~ URI::regexp)
         sid_server_mapping = {
-          0 => 'https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test',
-          1 => 'https://la7am6gdm8.execute-api.us-west-2.amazonaws.com/prod'
+          0 => 'https://testapi.smileidentity.com/v1',
+          1 => 'https://api.smileidentity.com/v1',
         }
         @url = sid_server_mapping[sid_server.to_i]
       else

--- a/lib/smile-identity-core/utilities.rb
+++ b/lib/smile-identity-core/utilities.rb
@@ -24,7 +24,7 @@ module SmileIdentityCore
       options[:return_history] ||= false
       options[:return_image_links] ||= false
 
-      security = request_security(use_legacy_sec_key: options.fetch(:use_legacy_sec_key, true))
+      security = request_security(use_new_signature: options.fetch(:signature, false))
       query_job_status(configure_job_query(user_id, job_id, options).merge(security))
     end
 
@@ -72,17 +72,17 @@ module SmileIdentityCore
       request.run
     end
 
-    def request_security(use_legacy_sec_key: true)
-      if use_legacy_sec_key
-        @timestamp = Time.now.to_i
-        {
-          sec_key: @signature_connection.generate_sec_key(@timestamp)[:sec_key],
-          timestamp: @timestamp,
-        }
-      else
+    def request_security(use_new_signature: false)
+      if use_new_signature
         @timestamp = Time.now.to_s
         {
           signature: @signature_connection.generate_signature(@timestamp)[:signature],
+          timestamp: @timestamp,
+        }
+      else
+        @timestamp = Time.now.to_i
+        {
+          sec_key: @signature_connection.generate_sec_key(@timestamp)[:sec_key],
           timestamp: @timestamp,
         }
       end

--- a/lib/smile-identity-core/utilities.rb
+++ b/lib/smile-identity-core/utilities.rb
@@ -25,7 +25,7 @@ module SmileIdentityCore
       options[:return_image_links] ||= false
 
       security = request_security(use_legacy_sec_key: options.fetch(:use_legacy_sec_key, true))
-      query_job_status(job_status_request(user_id, job_id, options).merge(security))
+      query_job_status(configure_job_query(user_id, job_id, options).merge(security))
     end
 
     private
@@ -88,7 +88,7 @@ module SmileIdentityCore
       end
     end
 
-    def job_status_request(user_id, job_id, options)
+    def configure_job_query(user_id, job_id, options)
       {
         user_id: user_id,
         job_id: job_id,

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -276,7 +276,7 @@ module SmileIdentityCore
 
     def configure_image_payload
       @images.map { |i|
-        if isImageFile?i[:image_type_id]
+        if image_file?(i[:image_type_id])
           {
             image_type_id: i[:image_type_id],
             image: '',
@@ -292,7 +292,7 @@ module SmileIdentityCore
       }
     end
 
-    def isImageFile?type
+    def image_file?(type)
       type.to_i == 0 || type.to_i == 1
     end
 

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -18,8 +18,8 @@ module SmileIdentityCore
       @sid_server = sid_server
       if !(sid_server =~ URI::regexp)
         sid_server_mapping = {
-          0 => 'https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test',
-          1 => 'https://la7am6gdm8.execute-api.us-west-2.amazonaws.com/prod'
+          0 => 'https://testapi.smileidentity.com/v1',
+          1 => 'https://api.smileidentity.com/v1',
         }
         @url = sid_server_mapping[sid_server.to_i]
       else

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -177,15 +177,15 @@ module SmileIdentityCore
       end
     end
 
-    def request_security(timestamp = Time.now, use_legacy_sec_key: true)
+    def request_security(use_legacy_sec_key: true)
       if use_legacy_sec_key
-        @timestamp = timestamp.to_i
+        @timestamp = Time.now.to_i
         {
           sec_key: SmileIdentityCore::Signature.new(@partner_id, @api_key).generate_sec_key(@timestamp)[:sec_key],
           timestamp: @timestamp,
         }
       else
-        @timestamp = timestamp.to_s
+        @timestamp = Time.now.to_s
         {
           signature: SmileIdentityCore::Signature.new(@partner_id, @api_key).generate_signature(@timestamp)[:signature],
           timestamp: @timestamp,

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -193,7 +193,7 @@ module SmileIdentityCore
       end
     end
 
-    def upload_request
+    def configure_prep_upload_json
       request_security(use_legacy_sec_key: @use_legacy_sec_key).merge(
         file_name: 'selfie.zip',
         smile_client_id: @partner_id,
@@ -210,7 +210,7 @@ module SmileIdentityCore
         url,
         method: 'POST',
         headers: {'Content-Type'=> "application/json"},
-        body: upload_request
+        body: configure_prep_upload_json
       )
 
       request.on_complete do |response|

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -130,19 +130,12 @@ module SmileIdentityCore
     end
 
     def options=(options)
-      updated_options = options
+      updated_options = options || {}
 
-      if updated_options.nil?
-        updated_options = {}
-      end
-
-      [:optional_callback, :return_job_status, :return_image_links, :return_history].map do |key|
-        if key != :optional_callback
-          updated_options[key] = check_boolean(key, options)
-        else
-          updated_options[key] = check_string(key, options)
-        end
-      end
+      updated_options[:optional_callback] = check_string(:optional_callback, options)
+      updated_options[:return_job_status] = check_boolean(:return_job_status, options)
+      updated_options[:return_image_links] = check_boolean(:return_image_links, options)
+      updated_options[:return_history] = check_boolean(:return_history, options)
 
       @options = updated_options
     end

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe SmileIdentityCore::IDApi do
 
   context 'ensure that the private methods behave correctly' do
     describe '#symbolize_keys' do
+      it 'deeply symbolizes the keys'
     end
 
     describe '#setup_requests' do

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SmileIdentityCore::IDApi do
       end
 
       it "sets the correct @url instance variable" do
-        expect(connection.instance_variable_get(:@url)).to eq('https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test')
+        expect(connection.instance_variable_get(:@url)).to eq('https://testapi.smileidentity.com/v1')
 
         connection = SmileIdentityCore::IDApi.new(partner_id, api_key, 'https://something34.api.us-west-2.amazonaws.com/something')
         expect(connection.instance_variable_get(:@url)).to eq('https://something34.api.us-west-2.amazonaws.com/something')
@@ -92,7 +92,7 @@ RSpec.describe SmileIdentityCore::IDApi do
 
         it 'sets it from a new `signature` option; defaults to using sec_key' do
           # It'll call #setup_requests and try to hit the request, so stop it:
-          Typhoeus.stub("https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test/id_verification")
+          Typhoeus.stub("https://testapi.smileidentity.com/v1/id_verification")
             .and_return(Typhoeus::Response.new(code: 200, body: {}.to_json))
 
           expect(flag_when_submitted_with_options(nil)).to eq(false)

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe SmileIdentityCore::IDApi do
 
         parsed_response = JSON.parse(connection.send(:id_verification_request))
         expect(parsed_response).to match(
-          'timestamp' => /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} -\d{4}/, # new signature!,
+          'timestamp' => /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-+]\d{4}/, # new signature!,
           'signature' => instance_of(String),
           'partner_id' => '004',
           'partner_params' => 'any partner params',

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -148,27 +148,21 @@ RSpec.describe SmileIdentityCore::IDApi do
     end
 
     describe '#configure_json' do
-      let(:parsed_response) { JSON.parse(connection.send(:configure_json)) }
+      it "returns a hash formatted for the request" do
+        connection.instance_variable_set(:@id_info, { id: 'info', is_merged: 'in, too' })
+        connection.instance_variable_set(:@timestamp, 123456789)
+        connection.instance_variable_set(:@partner_id, '004')
+        connection.instance_variable_set(:@partner_params, 'any partner params')
 
-      before(:each) {
-        connection.instance_variable_set('@id_info', id_info)
-      }
-
-      it 'returns the correct data type' do
-        expect(parsed_response).to be_kind_of(Hash)
-      end
-
-      ['timestamp', 'sec_key', 'partner_id', 'partner_params', 'id_number', 'id_type'].each do |key|
-        it "includes the #{key} key" do
-          expect(parsed_response).to have_key(key)
-        end
-      end
-    end
-
-    describe '#determine_sec_key' do
-      # NOTE: more testing done in Signature class
-      it 'contains a join in the signature' do
-        expect(connection.send(:determine_sec_key)).to include('|')
+        parsed_response = JSON.parse(connection.send(:configure_json))
+        expect(parsed_response).to match(
+          'timestamp' => 123456789,
+          'sec_key' => instance_of(String),
+          'partner_id' => '004',
+          'partner_params' => 'any partner params',
+          'id' => 'info',
+          'is_merged' => 'in, too'
+          )
       end
     end
   end

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe SmileIdentityCore::IDApi do
         connection = SmileIdentityCore::IDApi.new(partner_id, api_key, 'https://something34.api.us-west-2.amazonaws.com/something')
         expect(connection.instance_variable_get(:@url)).to eq('https://something34.api.us-west-2.amazonaws.com/something')
       end
-
     end
 
     describe '#submit_job' do
@@ -53,32 +52,41 @@ RSpec.describe SmileIdentityCore::IDApi do
           job_type: nil,
         }
 
-        expect { connection.submit_job(no_partner_parameters, id_info) }.to raise_error(ArgumentError, 'Please ensure that you send through partner params')
+        expect { connection.submit_job(no_partner_parameters, id_info) }
+          .to raise_error(ArgumentError, 'Please ensure that you send through partner params')
 
-        expect { connection.submit_job(array_partner_params, id_info) }.to raise_error(ArgumentError, 'Partner params needs to be a hash')
+        expect { connection.submit_job(array_partner_params, id_info) }
+          .to raise_error(ArgumentError, 'Partner params needs to be a hash')
 
-        expect { connection.submit_job(missing_partner_params, id_info) }.to raise_error(ArgumentError, 'Please make sure that job_type is included in the partner params')
+        expect { connection.submit_job(missing_partner_params, id_info) }
+          .to raise_error(ArgumentError, 'Please make sure that job_type is included in the partner params')
       end
 
       it 'validates that a job type 5 was submitted' do
-        expect { connection.submit_job({ user_id: 'dmKaJazQCziLc6Tw9lwcgzLo', job_id: 'DeXyJOGtaACFFfbZ2kxjuICE', job_type: 1 }, id_info) }.to raise_error(ArgumentError, 'Please ensure that you are setting your job_type to 5 to query ID Api')
+        expect {
+          connection.submit_job(
+            { user_id: 'dmKaJazQCziLc6Tw9lwcgzLo', job_id: 'DeXyJOGtaACFFfbZ2kxjuICE', job_type: 1 },
+            id_info)
+        }.to raise_error(ArgumentError, 'Please ensure that you are setting your job_type to 5 to query ID Api')
       end
 
       it 'validates the id_info' do
-        expect{ connection.submit_job(partner_params, nil) }.to raise_error(ArgumentError, "Please make sure that id_info not empty or nil")
-        expect{ connection.submit_job(partner_params, {}) }.to raise_error(ArgumentError, "Please make sure that id_info not empty or nil")
+        expect { connection.submit_job(partner_params, nil) }
+          .to raise_error(ArgumentError, "Please make sure that id_info not empty or nil")
+        expect { connection.submit_job(partner_params, {}) }
+          .to raise_error(ArgumentError, "Please make sure that id_info not empty or nil")
 
         [:country, :id_type, :id_number].each do |key|
           amended_id_info = id_info.clone
           amended_id_info[key] = ''
 
-          expect{ connection.submit_job(partner_params, amended_id_info) }.to raise_error(ArgumentError, "Please make sure that #{key.to_s} is included in the id_info")
+          expect { connection.submit_job(partner_params, amended_id_info) }
+            .to raise_error(ArgumentError, "Please make sure that #{key.to_s} is included in the id_info")
           amended_id_info = id_info.clone
         end
       end
     end
   end
-
 
   context 'ensure that the private methods behave correctly' do
     describe '#symbolize_keys' do
@@ -132,9 +140,12 @@ RSpec.describe SmileIdentityCore::IDApi do
         expect(JSON.parse(setup_response)['IDType']).to eq(id_info[:id_type])
         expect(JSON.parse(setup_response)['IDNumber']).to eq(id_info[:id_number])
 
-        # this test does not directly relate to the implementation of the library but it will help us to debug if any keys get removed from the response which will affect the partner.
-        expect(JSON.parse(setup_response).keys).to match_array(['JSONVersion', 'SmileJobID', 'PartnerParams', 'ResultType', 'ResultText', 'ResultCode', 'IsFinalResult', 'Actions', 'Country', 'IDType', 'IDNumber', 'ExpirationDate', 'FullName', 'DOB', 'Photo', 'sec_key', 'timestamp'])
-
+        # this test does not directly relate to the implementation of the library but it will help us to debug
+        # if any keys get removed from the response which will affect the partner.
+        expect(JSON.parse(setup_response).keys).to match_array([
+          'JSONVersion', 'SmileJobID', 'PartnerParams', 'ResultType', 'ResultText', 'ResultCode',
+          'IsFinalResult', 'Actions', 'Country', 'IDType', 'IDNumber', 'ExpirationDate', 'FullName',
+          'DOB', 'Photo', 'sec_key', 'timestamp'])
       end
     end
 
@@ -162,8 +173,5 @@ RSpec.describe SmileIdentityCore::IDApi do
         expect(connection.send(:determine_sec_key)).to include('|')
       end
     end
-
-
   end
-
 end

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe SmileIdentityCore::IDApi do
       end
     end
 
-    describe '#id_verification_request' do
+    describe '#configure_json' do
       before do
         connection.instance_variable_set(:@id_info, { id: 'info', is_merged: 'in, too' })
         connection.instance_variable_set(:@partner_id, '004')
@@ -176,7 +176,7 @@ RSpec.describe SmileIdentityCore::IDApi do
       it "returns a hash formatted for the request" do
         connection.instance_variable_set(:@use_legacy_sec_key, false)
 
-        parsed_response = JSON.parse(connection.send(:id_verification_request))
+        parsed_response = JSON.parse(connection.send(:configure_json))
         expect(parsed_response).to match(
           'timestamp' => /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-+]\d{4}/, # new signature!,
           'signature' => instance_of(String),
@@ -192,7 +192,7 @@ RSpec.describe SmileIdentityCore::IDApi do
         it 'puts in the original sec_key security stuff, and not the new signature stuff' do
           connection.instance_variable_set(:@use_legacy_sec_key, true)
 
-          parsed_response = JSON.parse(connection.send(:id_verification_request))
+          parsed_response = JSON.parse(connection.send(:configure_json))
           expect(parsed_response).to match(hash_including(
             'timestamp' => instance_of(Integer),
             'sec_key' => instance_of(String),

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -28,17 +28,10 @@ RSpec.describe SmileIdentityCore::IDApi do
   context 'ensure that the public methods behave correctly' do
 
     describe '#initialize' do
-      it "receives the correct attributes and returns an instance" do
-        expect(SmileIdentityCore::IDApi).to receive(:new).with(partner_id, api_key, sid_server).and_return(connection)
-
-        connection = SmileIdentityCore::IDApi.new(partner_id, api_key, sid_server)
-      end
-
-      [:@partner_id, :@api_key, :@sid_server].each do |instance_variable|
-        it "sets the #{instance_variable} instance variable" do
-          value = eval(instance_variable.slice(1..instance_variable.length-1))
-          expect(connection.instance_variable_get(instance_variable)).to eq(value)
-        end
+      it "sets the partner_id, api_key, and sid_server instance variables" do
+        expect(connection.instance_variable_get(:@partner_id)).to eq(partner_id)
+        expect(connection.instance_variable_get(:@api_key)).to eq(api_key)
+        expect(connection.instance_variable_get(:@sid_server)).to eq(sid_server)
       end
 
       it "sets the correct @url instance variable" do

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -77,12 +77,10 @@ RSpec.describe SmileIdentityCore::IDApi do
           .to raise_error(ArgumentError, "Please make sure that id_info not empty or nil")
 
         [:country, :id_type, :id_number].each do |key|
-          amended_id_info = id_info.clone
-          amended_id_info[key] = ''
+          amended_id_info = id_info.merge(key => '')
 
           expect { connection.submit_job(partner_params, amended_id_info) }
             .to raise_error(ArgumentError, "Please make sure that #{key.to_s} is included in the id_info")
-          amended_id_info = id_info.clone
         end
       end
     end

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe SmileIdentityCore::Utilities do
         partner_id: partner_id.to_s, # NB the .to_s
         history: return_history,
         image_links: return_image_links,
-        timestamp: instance_of(Integer),
-        sec_key: instance_of(String),
+        timestamp: /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} -\d{4}/, # new signature!
+        signature: instance_of(String), # new signature!
         )
 
       connection.get_job_status(
         user_id,
         job_id,
-        { return_history: return_history, return_image_links: return_image_links })
+        { return_history: return_history, return_image_links: return_image_links, use_legacy_sec_key: false })
     end
 
     context 'when options are missing' do
@@ -63,6 +63,23 @@ RSpec.describe SmileIdentityCore::Utilities do
           user_id, job_id, { 'return_history' => return_history, 'return_image_links' => return_image_links })
       end
     end
+
+    context 'when using the legacy sec_key' do
+      context 'because it is defaulted' do
+        it 'uses the legacy sec_key' do
+          expect(connection).to receive(:query_job_status).with(hash_including(
+            timestamp: instance_of(Integer), sec_key: instance_of(String)))
+          connection.get_job_status(user_id, job_id)
+        end
+      end
+      context 'because it is specified' do
+        it 'uses the legacy sec_key' do
+          expect(connection).to receive(:query_job_status).with(hash_including(
+            timestamp: instance_of(Integer), sec_key: instance_of(String)))
+          connection.get_job_status(user_id, job_id, use_legacy_sec_key: true)
+        end
+      end
+    end
   end
 
   describe '#query_job_status' do
@@ -70,10 +87,13 @@ RSpec.describe SmileIdentityCore::Utilities do
     let(:rsa) { OpenSSL::PKey::RSA.new(1024) }
     let(:partner_id) { 1 }
     let(:api_key) { Base64.encode64(rsa.public_key.to_pem) }
-    let(:timestamp) { Time.now.to_i }
+    let(:timestamp) { Time.now }
     let(:good_sec_key) do
-      hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp].join(":"))
+      hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp.to_i].join(":"))
       [Base64.encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
+    end
+    let(:good_signature) do
+      SmileIdentityCore::Signature.new(partner_id.to_s, api_key).generate_signature(timestamp.to_s)[:signature]
     end
 
     before(:each) {
@@ -89,25 +109,63 @@ RSpec.describe SmileIdentityCore::Utilities do
     end
 
     it 'returns the response' do
-      response_body = a_signed_response(signature: good_sec_key, timestamp: timestamp)
+      response_body = a_signed_response(signature: good_signature, timestamp: timestamp.to_s)
       typhoeus_response = Typhoeus::Response.new(code: 200, body: response_body)
       Typhoeus.stub(@url).and_return(typhoeus_response)
 
       expect(connection.send(:query_job_status, { some: 'json data' })).to eq(JSON.load(response_body))
     end
 
+    context 'for a legacy sec_key' do
+      it 'returns the response' do
+        response_body = a_signed_response(signature: good_sec_key, timestamp: timestamp.to_i)
+        typhoeus_response = Typhoeus::Response.new(code: 200, body: response_body)
+        Typhoeus.stub(@url).and_return(typhoeus_response)
+
+        expect(connection.send(:query_job_status, { some: 'json data', sec_key: 'present' }))
+          .to eq(JSON.load(response_body))
+      end
+    end
+
     context 'when the signature is invalid' do
       it 'raises' do
-        response_body = a_signed_response(signature: "fake signature", timestamp: timestamp)
+        response_body = a_signed_response(signature: "fake signature", timestamp: timestamp.to_s)
         typhoeus_response = Typhoeus::Response.new(code: 200, body: response_body)
         Typhoeus.stub(@url).and_return(typhoeus_response)
 
         expect {
           connection.send(:query_job_status, { some: 'json data' })
-        }.to raise_error(OpenSSL::PKey::RSAError)
-        # The specific error here matters less than the fact that it will raise.
-        # The code tries to raise a custom error, but we don't currently handle it properly.
-        # Leaving it this way for now, in case clients have come to rely on this behavior.
+        }.to raise_error('Unable to confirm validity of the job_status response')
+      end
+    end
+  end
+
+  describe '#request_security' do
+    let(:request_time) { Time.now }
+    context 'for a legacy sec_key' do
+      it 'should give a sec_key and timestamp' do
+        expect_any_instance_of(SmileIdentityCore::Signature).to receive(:generate_sec_key) do
+          { sec_key: 'a sec key', timestamp: request_time.to_i }
+        end
+
+        expect(connection.send(:request_security, request_time, use_legacy_sec_key: true))
+          .to eq(sec_key: 'a sec key', timestamp: request_time.to_i)
+
+        expect(connection.instance_variable_get(:@timestamp)).to eq(request_time.to_i)
+        # is that crucial? not sure
+      end
+    end
+    context 'for a newer signature' do
+      it 'should give a signature and timestamp' do
+        expect_any_instance_of(SmileIdentityCore::Signature).to receive(:generate_signature) do
+          { signature: 'a signature', timestamp: request_time.to_s }
+        end
+
+        expect(connection.send(:request_security, request_time, use_legacy_sec_key: false))
+          .to eq(signature: 'a signature', timestamp: request_time.to_s)
+
+        expect(connection.instance_variable_get(:@timestamp)).to eq(request_time.to_s)
+        # is that crucial? not sure
       end
     end
   end
@@ -128,8 +186,6 @@ RSpec.describe SmileIdentityCore::Utilities do
       expect(result[:partner_id]).to eq('4242') # NB: it gets .to_s'd
       expect(result[:history]).to eq(return_history)
       expect(result[:image_links]).to eq(return_image_links)
-      expect(result[:timestamp]).to eq("we only care here that it comes through")
-      expect(result[:sec_key]).to be_a(String)
     end
   end
 end

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -7,17 +7,9 @@ RSpec.describe SmileIdentityCore::Utilities do
   let(:timestamp) {Time.now.to_i}
 
   describe '#initialize' do
-    it "receives the correct attributes and returns an instance" do
-      expect(SmileIdentityCore::Utilities).to receive(:new).with(partner_id, api_key, sid_server).and_return(connection)
-
-      connection = SmileIdentityCore::Utilities.new(partner_id, api_key, sid_server)
-    end
-
-    [:@partner_id, :@api_key].each do |instance_variable|
-      it "sets the #{instance_variable} instance variable" do
-        value = eval(instance_variable.slice(1..instance_variable.length-1))
-        expect(connection.instance_variable_get(instance_variable)).to eq(value.to_s)
-      end
+    it "sets the partner_id and api_key instance variables" do
+      expect(connection.instance_variable_get(:@partner_id)).to eq(partner_id.to_s)
+      expect(connection.instance_variable_get(:@api_key)).to eq(api_key)
     end
 
     it "sets the correct @url instance variable" do

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SmileIdentityCore::Utilities do
       @sec_key = [Base64.encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
     }
 
-    it 'returns the response if job_complete is true' do
+    it 'returns the response' do
       body = {
         timestamp: "#{timestamp}",
         signature: "#{@sec_key}",

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SmileIdentityCore::Utilities do
     end
 
     it "sets the correct @url instance variable" do
-      expect(connection.instance_variable_get(:@url)).to eq('https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test')
+      expect(connection.instance_variable_get(:@url)).to eq('https://testapi.smileidentity.com/v1')
 
       connection = SmileIdentityCore::Utilities.new(partner_id, api_key, 'https://something34.api.us-west-2.amazonaws.com/something')
       expect(connection.instance_variable_get(:@url)).to eq('https://something34.api.us-west-2.amazonaws.com/something')

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -20,36 +20,51 @@ RSpec.describe SmileIdentityCore::Utilities do
   end
 
   describe '#query_job_status' do
-    let (:url) { 'https://some_server.com/dev01' }
-    let (:rsa) { OpenSSL::PKey::RSA.new(1024) }
-    let (:partner_id) { 1 }
-    let (:api_key) { Base64.encode64(rsa.public_key.to_pem) }
-    let (:timestamp)   { Time.now.to_i }
+    let(:url) { 'https://some_server.com/dev01' }
+    let(:rsa) { OpenSSL::PKey::RSA.new(1024) }
+    let(:partner_id) { 1 }
+    let(:api_key) { Base64.encode64(rsa.public_key.to_pem) }
+    let(:timestamp) { Time.now.to_i }
+    let(:good_sec_key) do
+      hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp].join(":"))
+      [Base64.encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
+    end
 
     before(:each) {
       connection.instance_variable_set('@url', url )
       connection.instance_variable_set('@api_key', api_key)
       connection.instance_variable_set('@partner_id', partner_id)
-
-      hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp].join(":"))
-      @sec_key = [Base64.encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
     }
 
-    it 'returns the response' do
-      body = {
-        timestamp: "#{timestamp}",
-        signature: "#{@sec_key}",
-        job_complete: true,
-        job_success: false,
-        code: "2302"
+    def a_signed_response(signature:, timestamp:)
+      {
+        timestamp: timestamp, signature: signature, job_complete: true, job_success: false, code: "2302"
       }.to_json
-
-      typhoeus_response = Typhoeus::Response.new(code: 200, body: body.to_s)
-      Typhoeus.stub(@url).and_return(typhoeus_response)
-
-      expect(connection.send(:query_job_status, '1', '1', {return_job_status: true, return_image_links: true})).to eq(JSON.load(body.to_s))
     end
 
+    it 'returns the response' do
+      response_body = a_signed_response(signature: good_sec_key, timestamp: timestamp)
+      typhoeus_response = Typhoeus::Response.new(code: 200, body: response_body)
+      Typhoeus.stub(@url).and_return(typhoeus_response)
+
+      expect(connection.send(:query_job_status, '1', '1', {return_job_status: true, return_image_links: true}))
+        .to eq(JSON.load(response_body))
+    end
+
+    context 'when the signature is invalid' do
+      it 'raises' do
+        response_body = a_signed_response(signature: "fake signature", timestamp: timestamp)
+        typhoeus_response = Typhoeus::Response.new(code: 200, body: response_body)
+        Typhoeus.stub(@url).and_return(typhoeus_response)
+
+        expect {
+          connection.send(:query_job_status, '1', '1', {return_job_status: true, return_image_links: true})
+        }.to raise_error(OpenSSL::PKey::RSAError)
+        # The specific error here matters less than the fact that it will raise.
+        # The code tries to raise a custom error, but we don't currently handle it properly.
+        # Leaving it this way for now, in case clients have come to rely on this behavior.
+      end
+    end
   end
 
   describe '#configure_job_query' do

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -140,36 +140,6 @@ RSpec.describe SmileIdentityCore::Utilities do
     end
   end
 
-  describe '#request_security' do
-    let(:request_time) { Time.now }
-    context 'for a legacy sec_key' do
-      it 'should give a sec_key and timestamp' do
-        expect_any_instance_of(SmileIdentityCore::Signature).to receive(:generate_sec_key) do
-          { sec_key: 'a sec key', timestamp: request_time.to_i }
-        end
-
-        expect(connection.send(:request_security, request_time, use_legacy_sec_key: true))
-          .to eq(sec_key: 'a sec key', timestamp: request_time.to_i)
-
-        expect(connection.instance_variable_get(:@timestamp)).to eq(request_time.to_i)
-        # is that crucial? not sure
-      end
-    end
-    context 'for a newer signature' do
-      it 'should give a signature and timestamp' do
-        expect_any_instance_of(SmileIdentityCore::Signature).to receive(:generate_signature) do
-          { signature: 'a signature', timestamp: request_time.to_s }
-        end
-
-        expect(connection.send(:request_security, request_time, use_legacy_sec_key: false))
-          .to eq(signature: 'a signature', timestamp: request_time.to_s)
-
-        expect(connection.instance_variable_get(:@timestamp)).to eq(request_time.to_s)
-        # is that crucial? not sure
-      end
-    end
-  end
-
   describe '#configure_job_query' do
     let(:partner_id) { 4242 }
     let(:return_history) { [true, false].sample }

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe SmileIdentityCore::Utilities do
   let (:rsa) { OpenSSL::PKey::RSA.new(1024) }
   let (:api_key) {Base64.encode64(rsa.public_key.to_pem)}
   let (:connection) { SmileIdentityCore::Utilities.new(partner_id, api_key, sid_server)}
-  let(:timestamp) {Time.now.to_i}
 
   describe '#initialize' do
     it "sets the partner_id and api_key instance variables" do

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SmileIdentityCore::Utilities do
       connection.get_job_status(
         user_id,
         job_id,
-        { return_history: return_history, return_image_links: return_image_links, use_legacy_sec_key: false })
+        { return_history: return_history, return_image_links: return_image_links, signature: true })
     end
 
     context 'when options are missing' do
@@ -72,11 +72,11 @@ RSpec.describe SmileIdentityCore::Utilities do
           connection.get_job_status(user_id, job_id)
         end
       end
-      context 'because it is specified' do
+      context 'because the `signature` option is false' do
         it 'uses the legacy sec_key' do
           expect(connection).to receive(:query_job_status).with(hash_including(
             timestamp: instance_of(Integer), sec_key: instance_of(String)))
-          connection.get_job_status(user_id, job_id, use_legacy_sec_key: true)
+          connection.get_job_status(user_id, job_id, signature: false)
         end
       end
     end

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe SmileIdentityCore::Utilities do
     end
   end
 
-  describe '#job_status_request' do
+  describe '#configure_job_query' do
     let(:partner_id) { 4242 }
     let(:return_history) { [true, false].sample }
     let(:return_image_links) { [true, false].sample }
@@ -178,7 +178,7 @@ RSpec.describe SmileIdentityCore::Utilities do
     it 'should set the correct keys on the payload' do
       connection.instance_variable_set(:@timestamp, "we only care here that it comes through")
 
-      result = connection.send(:job_status_request,
+      result = connection.send(:configure_job_query,
         111, 222, { return_history: return_history, return_image_links: return_image_links })
 
       expect(result[:user_id]).to eq(111)

--- a/spec/smile-identity-core/utilities_spec.rb
+++ b/spec/smile-identity-core/utilities_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SmileIdentityCore::Utilities do
         partner_id: partner_id.to_s, # NB the .to_s
         history: return_history,
         image_links: return_image_links,
-        timestamp: /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} -\d{4}/, # new signature!
+        timestamp: /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-+]\d{4}/, # new signature!
         signature: instance_of(String), # new signature!
         )
 

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -147,12 +147,10 @@ RSpec.describe SmileIdentityCore::WebApi do
 
         it 'validates the id_info' do
           [:country, :id_type, :id_number].each do |key|
-            amended_id_info = id_info.clone
-            amended_id_info[key] = ''
+            amended_id_info = id_info.merge(key => '')
 
             expect { connection.submit_job(partner_params, images, amended_id_info, options) }
               .to raise_error(ArgumentError, "Please make sure that #{key.to_s} is included in the id_info")
-            amended_id_info = id_info.clone
           end
         end
 

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe SmileIdentityCore::WebApi do
       end
 
       it "sets the correct @url instance variable" do
-        expect(connection.instance_variable_get(:@url)).to eq('https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test')
+        expect(connection.instance_variable_get(:@url)).to eq('https://testapi.smileidentity.com/v1')
 
         connection = SmileIdentityCore::WebApi.new(
           partner_id, default_callback, api_key, 'https://something34.api.us-west-2.amazonaws.com/something')

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -315,8 +315,8 @@ RSpec.describe SmileIdentityCore::WebApi do
       end
     end
 
-    describe '#upload_request' do
-      let(:parsed_response) { JSON.parse(connection.send(:upload_request)) }
+    describe '#configure_prep_upload_json' do
+      let(:parsed_response) { JSON.parse(connection.send(:configure_prep_upload_json)) }
 
       it 'returns the correct data type' do
         connection.instance_variable_set(:@partner_id, '001')

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -80,17 +80,10 @@ RSpec.describe SmileIdentityCore::WebApi do
 
   context 'ensure that the public methods behave correctly' do
     describe '#initialize' do
-      it "receives the correct attributes and returns an instance" do
-        expect(SmileIdentityCore::WebApi).to receive(:new).with(partner_id, default_callback, api_key, sid_server).and_return(connection)
-
-        connection = SmileIdentityCore::WebApi.new(partner_id, default_callback, api_key, sid_server)
-      end
-
-      [:@partner_id, :@api_key, :@sid_server].each do |instance_variable|
-        it "sets the #{instance_variable} instance variable" do
-          value = eval(instance_variable.slice(1..instance_variable.length-1))
-          expect(connection.instance_variable_get(instance_variable)).to eq(value)
-        end
+      it "sets the partner_id, api_key, and sid_server instance variables" do
+        expect(connection.instance_variable_get(:@partner_id)).to eq(partner_id)
+        expect(connection.instance_variable_get(:@api_key)).to eq(api_key)
+        expect(connection.instance_variable_get(:@sid_server)).to eq(sid_server)
       end
 
       it 'sets the @callback_url instance variable' do

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -634,7 +634,6 @@ RSpec.describe SmileIdentityCore::WebApi do
     end
 
     describe '#query_job_status' do
-      # NOTE: this is slow, need to fix
       let (:url) { 'https://some_server.com/dev01' }
       let (:rsa) { OpenSSL::PKey::RSA.new(1024) }
       let (:partner_id) { 1 }
@@ -655,6 +654,14 @@ RSpec.describe SmileIdentityCore::WebApi do
 
         hash_signature = Digest::SHA256.hexdigest([partner_id, timestamp].join(":"))
         @sec_key = [Base64.encode64(rsa.private_encrypt(hash_signature)), hash_signature].join('|')
+
+        def connection.sleep(n)
+          # TODO: This isn't ideal, but it's a way to speed up these specs.
+          # #query_job_status sleeps as it retries, which adds ~8 seconds to this spec run.
+          # Monkeypatching sleep on the connection object here no-ops it so it goes faster.
+          # Don't believe me? Uncomment:
+          # puts "sleep for #{n}!"
+        end
       }
 
       it 'returns the response if job_complete is true' do

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe SmileIdentityCore::WebApi do
 
         expect(parsed_response).to match(
           "signature" => instance_of(String),
-          "timestamp" => /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} -\d{4}/, # new signature!,
+          "timestamp" => /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-+]\d{4}/, # new signature!,
           "file_name" => "selfie.zip", # The code hard-codes this value
           "smile_client_id" => "001",
           "partner_params" => 'some partner params',
@@ -438,7 +438,7 @@ RSpec.describe SmileIdentityCore::WebApi do
             partner_params: 'partner params',
             smile_client_id: 'partner id',
             callback_url: 'example.com',
-            timestamp: /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} -\d{4}/, # new signature!,
+            timestamp: /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-+]\d{4}/, # new signature!,
             signature: instance_of(String), # new signature!
             userData: instance_of(Hash), # hard-coded, and spec'd below
             retry: 'false', # hard-coded

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -94,15 +94,14 @@ RSpec.describe SmileIdentityCore::WebApi do
       it "sets the correct @url instance variable" do
         expect(connection.instance_variable_get(:@url)).to eq('https://3eydmgh10d.execute-api.us-west-2.amazonaws.com/test')
 
-        connection = SmileIdentityCore::WebApi.new(partner_id, default_callback, api_key, 'https://something34.api.us-west-2.amazonaws.com/something')
+        connection = SmileIdentityCore::WebApi.new(
+          partner_id, default_callback, api_key, 'https://something34.api.us-west-2.amazonaws.com/something')
         expect(connection.instance_variable_get(:@url)).to eq('https://something34.api.us-west-2.amazonaws.com/something')
       end
-
     end
 
     describe '#submit_job' do
       context 'for validation' do
-
         it "validates the partner_params" do
           no_partner_parameters = nil
           array_partner_params = []
@@ -112,31 +111,38 @@ RSpec.describe SmileIdentityCore::WebApi do
             job_type: nil,
           }
 
-          expect { connection.submit_job(no_partner_parameters, images, id_info, options) }.to raise_error(ArgumentError, 'Please ensure that you send through partner params')
+          expect { connection.submit_job(no_partner_parameters, images, id_info, options) }
+            .to raise_error(ArgumentError, 'Please ensure that you send through partner params')
 
-          expect { connection.submit_job(array_partner_params, images, id_info, options) }.to raise_error(ArgumentError, 'Partner params needs to be a hash')
+          expect { connection.submit_job(array_partner_params, images, id_info, options) }
+            .to raise_error(ArgumentError, 'Partner params needs to be a hash')
 
-          expect { connection.submit_job(missing_partner_params, images, id_info, options) }.to raise_error(ArgumentError, 'Please make sure that job_type is included in the partner params')
+          expect { connection.submit_job(missing_partner_params, images, id_info, options) }
+            .to raise_error(ArgumentError, 'Please make sure that job_type is included in the partner params')
         end
 
         it 'validates the images' do
-         no_images = nil
-         hash_images = {}
-         empty_images = []
-         just_id_image = [
-           {
-             image_type_id: 1,
-             image_path: './tmp/id_image.png'
-           }
-         ]
+          no_images = nil
+          hash_images = {}
+          empty_images = []
+          just_id_image = [
+            {
+              image_type_id: 1,
+              image_path: './tmp/id_image.png'
+            }
+          ]
 
-         expect { connection.submit_job(partner_params, no_images, id_info, options) }.to raise_error(ArgumentError, 'Please ensure that you send through image details')
+          expect { connection.submit_job(partner_params, no_images, id_info, options) }
+           .to raise_error(ArgumentError, 'Please ensure that you send through image details')
 
-         expect { connection.submit_job(partner_params, hash_images, id_info, options) }.to raise_error(ArgumentError, 'Image details needs to be an array' )
+          expect { connection.submit_job(partner_params, hash_images, id_info, options) }
+           .to raise_error(ArgumentError, 'Image details needs to be an array' )
 
-         expect { connection.submit_job(partner_params, empty_images, id_info, options) }.to raise_error(ArgumentError, 'You need to send through at least one selfie image')
+          expect { connection.submit_job(partner_params, empty_images, id_info, options) }
+           .to raise_error(ArgumentError, 'You need to send through at least one selfie image')
 
-         expect { connection.submit_job(partner_params, just_id_image, id_info, options) }.to raise_error(ArgumentError, 'You need to send through at least one selfie image')
+          expect { connection.submit_job(partner_params, just_id_image, id_info, options) }
+           .to raise_error(ArgumentError, 'You need to send through at least one selfie image')
         end
 
         it 'validates the id_info' do
@@ -144,7 +150,8 @@ RSpec.describe SmileIdentityCore::WebApi do
             amended_id_info = id_info.clone
             amended_id_info[key] = ''
 
-            expect{ connection.submit_job(partner_params, images, amended_id_info, options) }.to raise_error(ArgumentError, "Please make sure that #{key.to_s} is included in the id_info")
+            expect { connection.submit_job(partner_params, images, amended_id_info, options) }
+              .to raise_error(ArgumentError, "Please make sure that #{key.to_s} is included in the id_info")
             amended_id_info = id_info.clone
           end
         end
@@ -157,12 +164,12 @@ RSpec.describe SmileIdentityCore::WebApi do
             return_history: false
           }
 
-          expect{ connection.submit_job(partner_params, images, id_info, options) }.to raise_error(ArgumentError, 'return_job_status needs to be a boolean')
+          expect { connection.submit_job(partner_params, images, id_info, options) }
+            .to raise_error(ArgumentError, 'return_job_status needs to be a boolean')
         end
       end
 
       it 'updates the callback_url when optional_callback is defined' do
-
         url = 'https://www.example.com'
         connection.instance_variable_set("@url", url)
 
@@ -189,19 +196,17 @@ RSpec.describe SmileIdentityCore::WebApi do
 
         expect(connection.instance_variable_get(:@callback_url)).to eq(options[:optional_callback])
         expect(connection.instance_variable_get(:@callback_url)).to_not eq(default_callback)
-
       end
 
       # xit 'ensures that we only except a png or jpg' do
       #   # check the image_path
       # end
-
     end
-
   end
 
   context 'ensure that the private methods behave correctly' do
-    # NOTE: In this gem, we do test the private methods because we have split up a lot of the logic into private methods that feed into the public method.
+    # NOTE: In this gem, we do test the private methods because we have split up a lot of
+    # the logic into private methods that feed into the public method.
 
     describe '#validate_return_data' do
       it 'validates that data is returned via the callback or job_status' do
@@ -209,13 +214,13 @@ RSpec.describe SmileIdentityCore::WebApi do
         connection.instance_variable_set('@options', options_with_job_status_true)
         expect {connection.send(:validate_return_data)}.not_to raise_error
 
-
         connection.instance_variable_set('@options', options)
-        expect {connection.send(:validate_return_data)}.to raise_error(ArgumentError, 'Please choose to either get your response via the callback or job status query')
+        expect { connection.send(:validate_return_data) }
+          .to raise_error(ArgumentError, 'Please choose to either get your response via the callback or job status query')
 
         connection.instance_variable_set('@options', options_with_job_status_true)
         connection.instance_variable_set('@callback_url', default_callback)
-        expect {connection.send(:validate_return_data)}.not_to raise_error
+        expect { connection.send(:validate_return_data) }.not_to raise_error
       end
     end
 
@@ -245,7 +250,8 @@ RSpec.describe SmileIdentityCore::WebApi do
       }
 
       it 'validates the id parameters required for job_type 1' do
-        expect { connection.send(:validate_enroll_with_id) }.to raise_error(ArgumentError, 'You are attempting to complete a job type 1 without providing an id card image or id info')
+        expect { connection.send(:validate_enroll_with_id) }
+          .to raise_error(ArgumentError, 'You are attempting to complete a job type 1 without providing an id card image or id info')
 
         connection.instance_variable_set('@images', images)
         expect { connection.send(:validate_enroll_with_id) }.not_to raise_error
@@ -253,7 +259,6 @@ RSpec.describe SmileIdentityCore::WebApi do
     end
 
     describe '#check_boolean' do
-
       it 'returns false for the key if the object does not exist' do
         options = {}
         expect(connection.send(:check_boolean, :return_job_status, options)).to be(false)
@@ -280,7 +285,8 @@ RSpec.describe SmileIdentityCore::WebApi do
       end
 
       it 'returns the string as it is when it exists' do
-        expect(connection.send(:check_string, :optional_callback, { :optional_callback => 'www.optional_callback' } )).to eq('www.optional_callback')
+        expect(connection.send(:check_string, :optional_callback, { :optional_callback => 'www.optional_callback' } ))
+          .to eq('www.optional_callback')
       end
     end
 
@@ -430,23 +436,18 @@ RSpec.describe SmileIdentityCore::WebApi do
 
       it 'correctly sets the image type value' do
         expect(connection.send(:configure_image_payload)[0][:image_type_id]).to eq(images_v2[0][:image_type_id])
-
         expect(connection.send(:configure_image_payload)[1][:image_type_id]).to eq(images_v2[1][:image_type_id])
       end
 
       it 'correctly sets the image value' do
         expect(connection.send(:configure_image_payload)[0][:image]).to eq('')
-
         expect(connection.send(:configure_image_payload)[1][:image]).to eq(images_v2[1][:image])
       end
 
       it 'correctly sets the file_name value' do
         expect(connection.send(:configure_image_payload)[0][:file_name]).to eq(File.basename(images_v2[0][:image]))
-
         expect(connection.send(:configure_image_payload)[1][:file_name]).to eq('')
       end
-
-
     end
 
     describe '#zip_up_file' do
@@ -579,8 +580,6 @@ RSpec.describe SmileIdentityCore::WebApi do
           expect(file).to_not include('id_image.png')
         end
       end
-
-
     end
 
     describe '#upload_file' do
@@ -600,9 +599,9 @@ RSpec.describe SmileIdentityCore::WebApi do
           Typhoeus.stub(url).and_return(typhoeus_response)
 
           connection.instance_variable_set('@options', options)
-          expect(connection.send(:upload_file, url, info_json, smile_job_id)).to eq({success: true, smile_job_id: smile_job_id}.to_json)
+          expect(connection.send(:upload_file, url, info_json, smile_job_id))
+            .to eq({success: true, smile_job_id: smile_job_id}.to_json)
         end
-
       end
 
       context 'if unsuccessful' do
@@ -617,21 +616,21 @@ RSpec.describe SmileIdentityCore::WebApi do
           typhoeus_response = Typhoeus::Response.new(code: 512, body: 'Some error')
           Typhoeus.stub(url).and_return(typhoeus_response)
 
-          expect {connection.send(:upload_file, url, info_json, smile_job_id) }.to raise_error(RuntimeError)
+          expect { connection.send(:upload_file, url, info_json, smile_job_id) }.to raise_error(RuntimeError)
         end
 
         it 'returns the correct message if we could not get an http response' do
           typhoeus_response = Typhoeus::Response.new(code: 0, body: 'Some error')
           Typhoeus.stub(url).and_return(typhoeus_response)
 
-          expect {connection.send(:upload_file, url, info_json, smile_job_id) }.to raise_error(RuntimeError)
+          expect { connection.send(:upload_file, url, info_json, smile_job_id) }.to raise_error(RuntimeError)
         end
 
         it 'returns the correct message if we received a non-successful http response' do
           typhoeus_response = Typhoeus::Response.new(code: 403, body: 'Some error')
           Typhoeus.stub(url).and_return(typhoeus_response)
 
-          expect {connection.send(:upload_file, url, info_json, smile_job_id) }.to raise_error(RuntimeError)
+          expect { connection.send(:upload_file, url, info_json, smile_job_id) }.to raise_error(RuntimeError)
         end
       end
     end
@@ -697,8 +696,6 @@ RSpec.describe SmileIdentityCore::WebApi do
       xit 'increments the counter if the counter is less than 20 and job_complete is not true' do
         # NOTE: to give more thought
       end
-
     end
   end
-
 end


### PR DESCRIPTION
This also includes all the commits from https://github.com/smileidentity/smile-identity-core-ruby/pull/13 Once that's merged into master and back into the `signature` branch, I'll probably rebase this, and there'll be a lot less noise. If you want to review before then, the commits are all ordered: refactors first, sec_key/signature work after...34449fd is the first signature-related commit here.