### PR TITLE
Send real SDK version in API requests

### DIFF
--- a/lib/smile-identity-core/version.rb
+++ b/lib/smile-identity-core/version.rb
@@ -1,3 +1,8 @@
 module SmileIdentityCore
   VERSION = "1.0.2"
+
+  def self.version_as_hash
+    major, minor, patch = *VERSION.split('.')
+    { majorVersion: major, minorVersion: minor, buildNumber: patch }
+  end
 end

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -239,11 +239,7 @@ module SmileIdentityCore
     def configure_info_json(server_information)
       info = {
         "package_information": {
-          "apiVersion": {
-            "buildNumber": 0,
-            "majorVersion": 2,
-            "minorVersion": 0
-          },
+          "apiVersion": SmileIdentityCore.version_as_hash,
           "language": "ruby"
         },
         "misc_information": {

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -399,9 +399,8 @@ RSpec.describe SmileIdentityCore::WebApi do
         end
 
         it 'sets the correct version information' do
-          expect(connection.send(:configure_info_json, 'the server information url')[:package_information][:apiVersion][:buildNumber]).to be(0)
-          expect(connection.send(:configure_info_json, 'the server information url')[:package_information][:apiVersion][:majorVersion]).to be(2)
-          expect(connection.send(:configure_info_json, 'the server information url')[:package_information][:apiVersion][:minorVersion]).to be(0)
+          expect(connection.send(:configure_info_json, 'the server information url')[:package_information][:apiVersion])
+            .to eq(SmileIdentityCore.version_as_hash)
         end
       end
 


### PR DESCRIPTION
I noticed this while working on the sec_key stuff. Seems like an easy win. If/when this merges, I'll handle merging it upstream through the `signature` branches.