### PR TITLE
Remove redudant return statements

### DIFF
--- a/lib/smile-identity-core/id_api.rb
+++ b/lib/smile-identity-core/id_api.rb
@@ -26,7 +26,7 @@ module SmileIdentityCore
         raise ArgumentError, 'Please ensure that you are setting your job_type to 5 to query ID Api'
       end
 
-      return setup_requests
+      setup_requests
     end
 
     def partner_params=(partner_params)

--- a/lib/smile-identity-core/signature.rb
+++ b/lib/smile-identity-core/signature.rb
@@ -14,7 +14,7 @@ module SmileIdentityCore
         public_key = OpenSSL::PKey::RSA.new(Base64.decode64(@api_key))
         @sec_key = [Base64.encode64(public_key.public_encrypt(hash_signature)), hash_signature].join('|')
 
-        return {
+        {
           sec_key: @sec_key,
           timestamp: @timestamp
         }
@@ -31,7 +31,7 @@ module SmileIdentityCore
         public_key = OpenSSL::PKey::RSA.new(Base64.decode64(@api_key))
         decrypted = public_key.public_decrypt(Base64.decode64(encrypted))
 
-        return decrypted == hash_signature
+        decrypted == hash_signature
       rescue => e
         raise e
       end
@@ -43,7 +43,7 @@ module SmileIdentityCore
       hmac.update(@partner_id)
       hmac.update("sid_request")
       signature = Base64.strict_encode64(hmac.digest())
-      return {
+      {
         signature: signature,
         timestamp: timestamp.to_s
       }

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -48,7 +48,7 @@ module SmileIdentityCore
 
       validate_return_data
 
-      return setup_requests
+      setup_requests
     end
 
     def get_job_status(partner_params, options)
@@ -59,7 +59,7 @@ module SmileIdentityCore
       job_id = partner_params[:job_id]
 
       utilities = SmileIdentityCore::Utilities.new(@partner_id, @api_key, @sid_server)
-      return utilities.get_job_status(user_id, job_id, options);
+      utilities.get_job_status(user_id, job_id, options);
     end
 
     def partner_params=(partner_params)
@@ -166,14 +166,14 @@ module SmileIdentityCore
         raise ArgumentError, "#{key} needs to be a boolean"
       end
 
-      return obj[key]
+      obj[key]
     end
 
     def check_string(key, obj)
       if (!obj || !obj[key])
-        return ''
+        ''
       else
-        return obj[key]
+        obj[key]
       end
     end
 
@@ -270,7 +270,7 @@ module SmileIdentityCore
         "images": configure_image_payload,
         "server_information": server_information
       }
-      return info
+      info
     end
 
     def configure_image_payload
@@ -356,9 +356,9 @@ module SmileIdentityCore
       response = @utilies_connection.get_job_status(@partner_params[:user_id], @partner_params[:job_id], @options)
 
       if response && (response['job_complete'] == true || counter == 20)
-        return response
+        response
       else
-        return query_job_status(counter)
+        query_job_status(counter)
       end
 
     end


### PR DESCRIPTION
A ruby method always returns the last evaluated expression/statement. No need for us to specify the return.
