### PR TITLE
Refactor request security method

### DIFF
--- a/lib/smile-identity-core/id_api.rb
+++ b/lib/smile-identity-core/id_api.rb
@@ -97,20 +97,30 @@ module SmileIdentityCore
         .to_json
     end
 
+    def signature_generator
+      SmileIdentityCore::Signature.new(@partner_id, @api_key)
+    end
+
+    def signature(timestamp: Time.now.to_s)
+      signature = signature_generator.generate_signature(timestamp)[:signature]
+      {
+        signature: signature,
+        timestamp: timestamp
+      }
+    end
+
+    def sec_key(timestamp: Time.now.to_s)
+      sec_key = signature_generator.generate_sec_key(timestamp)[:sec_key]
+      {
+        sec_key: sec_key,
+        timestamp: timestamp
+      }
+    end
+
     def request_security(use_new_signature: true)
-      if use_new_signature
-        @timestamp = Time.now.to_s
-        {
-          signature: SmileIdentityCore::Signature.new(@partner_id, @api_key).generate_signature(@timestamp)[:signature],
-          timestamp: @timestamp,
-        }
-      else
-        @timestamp = Time.now.to_i
-        {
-          sec_key: SmileIdentityCore::Signature.new(@partner_id, @api_key).generate_sec_key(@timestamp)[:sec_key],
-          timestamp: @timestamp,
-        }
-      end
+      return signature if use_new_signature
+
+      sec_key
     end
   end
 end

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -192,12 +192,11 @@ RSpec.describe SmileIdentityCore::IDApi do
         it 'puts in the original sec_key security stuff, and not the new signature stuff' do
           connection.instance_variable_set(:@use_new_signature, false)
 
-          parsed_response = JSON.parse(connection.send(:configure_json))
-          expect(parsed_response).to match(hash_including(
-            'timestamp' => instance_of(Integer),
-            'sec_key' => instance_of(String),
-            ))
-          expect(parsed_response).not_to have_key 'signature'
+          parsed_response = JSON.parse(connection.send(:configure_json), { symbolize_names: true })
+
+          keys = %i[sec_key timestamp is_merged partner_params id partner_id]
+          expect(parsed_response).to include(*keys)
+          expect(parsed_response).not_to have_key(:signature)
         end
       end
     end


### PR DESCRIPTION
Allows usage of `sec_key` and `signature` methods individually in cases where we are sure we want to use only one of them.

Now if you have a method that you know for sure will need to use the new security key `signature` you can call `signature` method without worrying about the value of `use_new_signature`. IMO it make code more direct by showing what was intended.

```ruby
def some_method
  api_call_that_requires_sec_key(url, { sec_key: sec_key }
end

def another_method
  api_call_that_requires_signature(url, { signature:  signature }
end
```

Compare the above with

```ruby
def some_method
  api_call_that_requires_sec_key(url, { sec_key: request_security(use_new_signature(false) }
end

def another_method
  api_call_that_requires_signature(url, { signature: request_security }
end
```