### PR TITLE
Add a new way to configure the library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in smile-identity-core.gemspec
 gemspec
+
+gem "pry-byebug", "~> 3.9", :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.3)
+    coderay (1.1.3)
     diff-lcs (1.3)
     docile (1.1.5)
     ethon (0.12.0)
       ffi (>= 1.3.0)
     ffi (1.13.1)
     json (2.5.1)
+    method_source (1.0.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -42,6 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  pry-byebug (~> 3.9)
   rake (~> 10.0)
   rspec (~> 3.0)
   simplecov (~> 0.12.0)

--- a/lib/smile-identity-core.rb
+++ b/lib/smile-identity-core.rb
@@ -3,6 +3,7 @@ require "smile-identity-core/web_api.rb"
 require "smile-identity-core/id_api.rb"
 require "smile-identity-core/signature.rb"
 require "smile-identity-core/utilities.rb"
+require "smile-identity-core/configuration.rb"
 
 module SmileIdentityCore
   class Error < StandardError; end

--- a/lib/smile-identity-core.rb
+++ b/lib/smile-identity-core.rb
@@ -1,9 +1,4 @@
-require "smile-identity-core/version"
-require "smile-identity-core/web_api.rb"
-require "smile-identity-core/id_api.rb"
-require "smile-identity-core/signature.rb"
-require "smile-identity-core/utilities.rb"
-require "smile-identity-core/configuration.rb"
+Dir["#{File.dirname(__FILE__)}/smile-identity-core/**/*.rb"].sort.each { |f| require(f) }
 
 module SmileIdentityCore
   class Error < StandardError; end

--- a/lib/smile-identity-core/configuration.rb
+++ b/lib/smile-identity-core/configuration.rb
@@ -1,0 +1,19 @@
+module SmileIdentityCore
+  class Configuration
+    attr_accessor :partner_id,
+                  :default_callback,
+                  :api_key,
+                  :sid_server
+    def initialize
+      yield self if block_given?
+    end
+  end
+
+  def self.configure(&block)
+    @config = Configuration.new(&block)
+  end
+
+  def self.config
+    @config
+  end
+end

--- a/lib/smile-identity-core/id_api.rb
+++ b/lib/smile-identity-core/id_api.rb
@@ -1,19 +1,20 @@
 module SmileIdentityCore
   class IDApi
 
-    def initialize(partner_id, api_key, sid_server)
-      @partner_id = partner_id.to_s
-      @api_key = api_key
+    def initialize()
+      config = SmileIdentityCore.config
+      @partner_id = config.partner_id.to_s
+      @api_key = config.api_key
 
-      @sid_server = sid_server
-      if !(sid_server =~ URI::regexp)
+      @sid_server = config.sid_server
+      if !(@sid_server =~ URI::regexp)
         sid_server_mapping = {
           0 => 'https://testapi.smileidentity.com/v1',
           1 => 'https://api.smileidentity.com/v1',
         }
-        @url = sid_server_mapping[sid_server.to_i]
+        @url = sid_server_mapping[@sid_server.to_i]
       else
-        @url = sid_server
+        @url = @sid_server
       end
     end
 

--- a/spec/smile-identity-core/configuration_spec.rb
+++ b/spec/smile-identity-core/configuration_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe SmileIdentityCore::Configuration do
+
+  describe 'configuration' do
+    let(:partner_id) { '002' }
+    let(:api_key) { 'xxx' }
+    let(:default_callback) { 'http://localhost' }
+    let(:sid_server) { 'http://sid-server' }
+
+    let(:configuration) do
+      described_class.new do |config|
+        config.partner_id = partner_id
+        config.api_key = api_key
+        config.default_callback = default_callback
+        config.sid_server = sid_server
+      end
+    end
+
+    context 'configuration' do
+      it 'accepts a partner_id' do
+        expect(configuration.partner_id).to eq(partner_id)
+      end
+
+      it 'accepts an api_key' do
+        expect(configuration.api_key).to eq(api_key)
+      end
+
+      it 'accepts a default_callback' do
+        expect(configuration.default_callback).to eq(default_callback)
+      end
+
+      it 'accepts a sid_server' do
+        expect(configuration.sid_server).to eq(sid_server)
+      end
+    end
+  end
+end

--- a/spec/smile-identity-core/id_api_spec.rb
+++ b/spec/smile-identity-core/id_api_spec.rb
@@ -1,8 +1,18 @@
 RSpec.describe SmileIdentityCore::IDApi do
+
   let (:partner_id) {'001'}
   let (:api_key) {Base64.encode64( OpenSSL::PKey::RSA.new(1024).public_key.to_pem)}
   let (:sid_server) {0}
-  let (:connection) { SmileIdentityCore::IDApi.new(partner_id, api_key, sid_server)}
+
+  before do
+    SmileIdentityCore.configure do |config|
+      config.partner_id = partner_id
+      config.api_key = api_key
+      config.sid_server = sid_server
+    end
+  end
+
+  let (:connection) { SmileIdentityCore::IDApi.new }
 
   let (:partner_params) {
     {
@@ -32,13 +42,16 @@ RSpec.describe SmileIdentityCore::IDApi do
         expect(connection.instance_variable_get(:@partner_id)).to eq(partner_id)
         expect(connection.instance_variable_get(:@api_key)).to eq(api_key)
         expect(connection.instance_variable_get(:@sid_server)).to eq(sid_server)
+        expect(connection.instance_variable_get(:@url)).to eq('https://testapi.smileidentity.com/v1')
       end
 
-      it "sets the correct @url instance variable" do
-        expect(connection.instance_variable_get(:@url)).to eq('https://testapi.smileidentity.com/v1')
+      context 'setting url' do
+        let(:sid_server) {'https://something34.api.us-west-2.amazonaws.com/something'}
 
-        connection = SmileIdentityCore::IDApi.new(partner_id, api_key, 'https://something34.api.us-west-2.amazonaws.com/something')
-        expect(connection.instance_variable_get(:@url)).to eq('https://something34.api.us-west-2.amazonaws.com/something')
+        it "sets the correct @url instance variable" do
+          connection = SmileIdentityCore::IDApi.new
+          expect(connection.instance_variable_get(:@url)).to eq(sid_server)
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'simplecov'
+require 'pry-byebug'
 
 SimpleCov.start do
   add_filter '/spec/'


### PR DESCRIPTION
## Summary
Adds a new way to configure the library. The new way removes the need to pass config options to every class initialization.
We can use 1 config for all the classes.
### Example

```ruby
SmileIdentityCore.configure do | config|
  config.api_key = 'xxx'
  config.default_callback = 'xxx'
  config.partner_id = 'xxx'
end
```