### PR TITLE
Fix https://docs.smileidentity.com redirecting to github 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For extensive instructions on usage of the library and sample codes, please refe
 
 ## Getting Help
 
-For usage questions, the best resource is [our official documentation](docs.smileidentity.com). However, if you require further assistance, you can file a [support ticket via our portal](https://portal.smileidentity.com/partner/support/tickets) or visit the [contact us page](https://portal.smileidentity.com/partner/support/tickets) on our website.
+For usage questions, the best resource is [our official documentation](https://docs.smileidentity.com). However, if you require further assistance, you can file a [support ticket via our portal](https://portal.smileidentity.com/partner/support/tickets) or visit the [contact us page](https://portal.smileidentity.com/partner/support/tickets) on our website.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ confirm_signature - ensure a response is truly from the Smile Identity server by
 
 The Utilities Class allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
 get_job_status - retrieve information & results of a job. Read more on job status in the Smile Identity documentation.
-get_smile_id_services - general information about different smile identity products such as required inputs for each supported id type.
+~~get_smile_id_services - general information about different smile identity products such as required inputs for each supported id type.~~
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ confirm_signature - ensure a response is truly from the Smile Identity server by
 
 The Utilities Class allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
 get_job_status - retrieve information & results of a job. Read more on job status in the Smile Identity documentation.
-~~get_smile_id_services - general information about different smile identity products such as required inputs for each supported id type.~~
 
 ## Installation
 


### PR DESCRIPTION
Fixes documentation redirecting to github 404 page instead of https://docs.smileidentity.com