### PR TITLE
Change to cadwallion/publish-rubygems-action to allow publishing to gpr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Release Gem
-      uses: discourse/publish-rubygems-action@v2
+      uses: cadwallion/publish-rubygems-action@master
       env:
         RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change allows for releasing to GitHub Package Registry