### PR TITLE
Revert "config: use `powerhome/publish-rubygems-action` until cadwall…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         set-safe-directory: false
     - name: Release Gem
-      uses: powerhome/publish-rubygems-action@git-safe-directory
+      uses: cadwallion/publish-rubygems-action@master
       env:
         RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…ion updates (#56)"

This reverts commit 1dc7d045a6f766ac78b3eb2c641743f5085d2df3.