### PR TITLE
Allow leaving id_number and id_type fields empty in id_info for JT6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2023-08-31
+### Changed
+- Don't validate the presence of `id_type` and `id_number` for Document Verification jobs
+
 ## [2.2.0] - 2023-04-05
 ### Added
 - Adds support for AML check
 ### Changed
 - Fix business verification docstrings
-- Don't validate the presence of `id_type` and `id_number` for Document Verification jobs
 
 ## [2.1.2] - 2023-03-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds support for AML check
 ### Changed
 - Fix business verification docstrings
+- Don't validate the presence of `id_type` and `id_number` for Document Verification jobs
 
 ## [2.1.2] - 2023-03-09
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,20 +9,15 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    coderay (1.1.3)
     diff-lcs (1.3)
     docile (1.1.5)
     ethon (0.16.0)
       ffi (>= 1.15.0)
     ffi (1.15.5)
     json (2.5.1)
-    method_source (1.0.0)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     rainbow (3.1.1)
     rake (12.3.3)
     regexp_parser (2.6.0)
@@ -72,7 +67,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  pry (~> 0.14.2)
   rake (~> 12.3)
   rspec (~> 3.0)
   rubocop (~> 1.37.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smile-identity-core (2.2.0)
+    smile-identity-core (2.2.1)
       rubyzip (~> 1.2, >= 1.2.3)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,15 +9,20 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    coderay (1.1.3)
     diff-lcs (1.3)
     docile (1.1.5)
     ethon (0.16.0)
       ffi (>= 1.15.0)
     ffi (1.15.5)
     json (2.5.1)
+    method_source (1.0.0)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rainbow (3.1.1)
     rake (12.3.3)
     regexp_parser (2.6.0)
@@ -67,6 +72,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  pry (~> 0.14.2)
   rake (~> 12.3)
   rspec (~> 3.0)
   rubocop (~> 1.37.1)

--- a/lib/smile-identity-core/version.rb
+++ b/lib/smile-identity-core/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module SmileIdentityCore
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
   SOURCE_SDK = 'Ruby'
 end

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -91,8 +91,10 @@ module SmileIdentityCore
       # if it's a boolean
       updated_id_info[:entered] = id_info[:entered].to_s if !updated_id_info[:entered].nil? == updated_id_info[:entered]
 
-      if updated_id_info[:entered] && updated_id_info[:entered] == 'true' && @partner_params[:job_type].to_i != JobType::DOCUMENT_VERIFICATION
-        %i[country id_type id_number].each do |key|
+      if updated_id_info[:entered] == 'true'
+        keys = %i[country id_type id_number]
+        keys -= %i[id_type id_number] if @partner_params[:job_type].to_i == JobType::DOCUMENT_VERIFICATION
+        keys.each do |key|
           raise ArgumentError, "Please make sure that #{key} is included in the id_info" if id_info[key].to_s.empty?
         end
       end

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -7,7 +7,6 @@ require 'openssl'
 require 'uri'
 require 'typhoeus'
 require 'zip'
-require 'pry'
 
 module SmileIdentityCore
   # Allows Identity verifications of ids with images

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -7,6 +7,7 @@ require 'openssl'
 require 'uri'
 require 'typhoeus'
 require 'zip'
+require 'pry'
 
 module SmileIdentityCore
   # Allows Identity verifications of ids with images
@@ -93,6 +94,7 @@ module SmileIdentityCore
 
       if updated_id_info[:entered] && updated_id_info[:entered] == 'true'
         %i[country id_type id_number].each do |key|
+          next if @partner_params[:job_type].to_i == JobType::DOCUMENT_VERIFICATION
           raise ArgumentError, "Please make sure that #{key} is included in the id_info" if id_info[key].to_s.empty?
         end
       end

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -91,12 +91,14 @@ module SmileIdentityCore
       # if it's a boolean
       updated_id_info[:entered] = id_info[:entered].to_s if !updated_id_info[:entered].nil? == updated_id_info[:entered]
 
-      if updated_id_info[:entered] == 'true'
-        keys = if @partner_params[:job_type].to_i == JobType::DOCUMENT_VERIFICATION
-          %i[country]
-        else
-          %i[country id_type id_number]
-        end
+      is_jt6 = @partner_params[:job_type].to_i == JobType::DOCUMENT_VERIFICATION
+      keys = if is_jt6
+        %i[country]
+      else
+        %i[country id_type id_number]
+      end
+
+      if updated_id_info[:entered] == 'true' || is_jt6
         keys.each do |key|
           raise ArgumentError, "Please make sure that #{key} is included in the id_info" if id_info[key].to_s.empty?
         end

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -92,8 +92,11 @@ module SmileIdentityCore
       updated_id_info[:entered] = id_info[:entered].to_s if !updated_id_info[:entered].nil? == updated_id_info[:entered]
 
       if updated_id_info[:entered] == 'true'
-        keys = %i[country id_type id_number]
-        keys -= %i[id_type id_number] if @partner_params[:job_type].to_i == JobType::DOCUMENT_VERIFICATION
+  keys = if @partner_params[:job_type].to_i == JobType::DOCUMENT_VERIFICATION
+    %i[country]
+  else
+    %i[country id_type id_number]
+  end
         keys.each do |key|
           raise ArgumentError, "Please make sure that #{key} is included in the id_info" if id_info[key].to_s.empty?
         end

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -91,9 +91,8 @@ module SmileIdentityCore
       # if it's a boolean
       updated_id_info[:entered] = id_info[:entered].to_s if !updated_id_info[:entered].nil? == updated_id_info[:entered]
 
-      if updated_id_info[:entered] && updated_id_info[:entered] == 'true'
+      if updated_id_info[:entered] && updated_id_info[:entered] == 'true' && @partner_params[:job_type].to_i != JobType::DOCUMENT_VERIFICATION
         %i[country id_type id_number].each do |key|
-          next if @partner_params[:job_type].to_i == JobType::DOCUMENT_VERIFICATION
           raise ArgumentError, "Please make sure that #{key} is included in the id_info" if id_info[key].to_s.empty?
         end
       end

--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -92,11 +92,11 @@ module SmileIdentityCore
       updated_id_info[:entered] = id_info[:entered].to_s if !updated_id_info[:entered].nil? == updated_id_info[:entered]
 
       if updated_id_info[:entered] == 'true'
-  keys = if @partner_params[:job_type].to_i == JobType::DOCUMENT_VERIFICATION
-    %i[country]
-  else
-    %i[country id_type id_number]
-  end
+        keys = if @partner_params[:job_type].to_i == JobType::DOCUMENT_VERIFICATION
+          %i[country]
+        else
+          %i[country id_type id_number]
+        end
         keys.each do |key|
           raise ArgumentError, "Please make sure that #{key} is included in the id_info" if id_info[key].to_s.empty?
         end

--- a/smile-identity-core.gemspec
+++ b/smile-identity-core.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'pry', '~> 0.14.2'
   spec.add_development_dependency 'rubocop', '~> 1.37.1'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.14.1'

--- a/smile-identity-core.gemspec
+++ b/smile-identity-core.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'pry', '~> 0.14.2'
   spec.add_development_dependency 'rubocop', '~> 1.37.1'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.14.1'

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -140,6 +140,17 @@ RSpec.describe SmileIdentityCore::WebApi do
           end
         end
 
+        it 'allows leaving country and id_type fields empty in id_info for JT6' do
+          %i[country id_type].each do |key|
+            amended_id_info = id_info.merge(key => '')
+
+            expect { connection.submit_job(partner_params.merge({
+              job_type: SmileIdentityCore::JobType::DOCUMENT_VERIFICATION
+            }), images, amended_id_info, options) }
+              .not_to raise_error(ArgumentError, "Please make sure that #{key} is included in the id_info")
+          end
+        end
+
         it 'checks that return_job_status is a boolean' do
           expect { connection.submit_job(partner_params, images, id_info, options.merge(return_job_status: 'false')) }
             .to raise_error(ArgumentError, 'return_job_status needs to be a boolean')

--- a/spec/smile-identity-core/web_api_spec.rb
+++ b/spec/smile-identity-core/web_api_spec.rb
@@ -141,13 +141,27 @@ RSpec.describe SmileIdentityCore::WebApi do
         end
 
         it 'allows leaving country and id_type fields empty in id_info for JT6' do
+          connection.instance_variable_set('@url', 'https://www.example.com')
+          response_upload_url = 'https://smile-uploads-somewhere.amazonaws.com/videos/a_signed_url'
+          body = {
+            'upload_url' => response_upload_url,
+            'ref_id' => '125-0000000583-s8fqo7ju2ji2u32hhu4us11bq3yhww',
+            'smile_job_id' => '0000000583',
+            'camera_config' => 'null',
+            'code' => '2202'
+          }.to_json
+          Typhoeus.stub('https://www.example.com/upload').and_return(Typhoeus::Response.new(code: 200, body: body))
+          allow(IO).to receive(:read).with('./tmp/selfie.png').and_return('')
+          allow(IO).to receive(:read).with('./tmp/id_image.png').and_return('')
+          Typhoeus.stub(response_upload_url).and_return(Typhoeus::Response.new(code: 200))
+
           %i[country id_type].each do |key|
             amended_id_info = id_info.merge(key => '')
 
             expect { connection.submit_job(partner_params.merge({
               job_type: SmileIdentityCore::JobType::DOCUMENT_VERIFICATION
             }), images, amended_id_info, options) }
-              .not_to raise_error(ArgumentError, "Please make sure that #{key} is included in the id_info")
+              .not_to raise_error
           end
         end
 


### PR DESCRIPTION
This PR introduces changes to allow `country` and `id_type` fields to be empty in `id_info` for JT6