### PR TITLE
update domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Smile Identity provides the best solutions for real time Digital KYC, identity verification, user onboarding, and user authentication across Africa. Our server side libraries make it easy to integrate us on the server-side. Since the library is server-side, you will be required to pass the images (if required) to the library.
 
-If you haven’t already, [sign up for a free Smile Identity account](https://www.smileidentity.com/schedule-a-demo/), which comes with Sandbox access.
+If you haven’t already, [sign up for a free Smile Identity account](https://usesmileid.com/talk-to-an-expert/), which comes with Sandbox access.
 
 Please see [CHANGELOG.md](CHANGELOG.md) for release versions and changes.
 
@@ -12,12 +12,12 @@ The library exposes four classes namely; the WebApi class, the IDApi class, the 
 
 The WebApi class has the following public methods:
 
-- `submit_job` - handles submission of any of Smile Identity products that requires an image i.e. [Biometric KYC](https://docs.smileidentity.com/products/biometric-kyc), [Document Verification](https://docs.smileidentity.com/products/document-verification), [SmartSelfieTM Authentication](https://docs.smileidentity.com/products/biometric-authentication) and [Business Verification](https://docs.smileidentity.com/products/for-businesses-kyb/business-verification).
-- `get_web_token` - handles generation of web token, if you are using the [Hosted Web Integration](https://docs.smileidentity.com/web-mobile-web/web-integration-beta).
+- `submit_job` - handles submission of any of Smile Identity products that requires an image i.e. [Biometric KYC](https://docs.usesmileid.com/products/biometric-kyc), [Document Verification](https://docs.usesmileid.com/products/document-verification), [SmartSelfieTM Authentication](https://docs.usesmileid.com/products/biometric-authentication) and [Business Verification](https://docs.usesmileid.com/products/for-businesses-kyb/business-verification).
+- `get_web_token` - handles generation of web token, if you are using the [Hosted Web Integration](https://docs.usesmileid.com/web-mobile-web/web-integration-beta).
 
 The IDApi class has the following public method:
 
-- `submit_job` - handles submission of [Enhanced KYC](https://docs.smileidentity.com/products/identity-lookup) and [Basic KYC](https://docs.smileidentity.com/products/id-verification).
+- `submit_job` - handles submission of [Enhanced KYC](https://docs.usesmileid.com/products/identity-lookup) and [Basic KYC](https://docs.usesmileid.com/products/id-verification).
 
 The Signature class has the following public methods:
 
@@ -26,7 +26,7 @@ The Signature class has the following public methods:
 
 The Utilities Class allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
 
-- `get_job_status` - retrieve information & results of a job. Read more on job status in the [Smile Identity documentation](https://docs.smileidentity.com/further-reading/job-status).
+- `get_job_status` - retrieve information & results of a job. Read more on job status in the [Smile Identity documentation](https://docs.usesmileid.com/further-reading/job-status).
 
 ## Installation
 
@@ -52,13 +52,13 @@ gem install smile-identity-core
 
 ## Documentation
 
-For extensive instructions on usage of the library and sample codes, please refer to the official Smile Identity [documentation](https://docs.smileidentity.com/server-to-server/ruby).
+For extensive instructions on usage of the library and sample codes, please refer to the official Smile Identity [documentation](https://docs.usesmileid.com/server-to-server/ruby).
 
 Before that, you should take a look at the examples in the [examples](/examples) folder.
 
 ## Getting Help
 
-For usage questions, the best resource is [our official documentation](https://docs.smileidentity.com). However, if you require further assistance, you can file a [support ticket via our portal](https://portal.smileidentity.com/partner/support/tickets) or visit the [contact us page](https://portal.smileidentity.com/partner/support/tickets) on our website.
+For usage questions, the best resource is [our official documentation](https://docs.usesmileid.com). However, if you require further assistance, you can file a [support ticket via our portal](https://portal.usesmileid.com/partner/support/tickets) or visit the [contact us page](https://portal.usesmileid.com/partner/support/tickets) on our website.
 
 ## Contributing
 

--- a/examples/aml_check.rb
+++ b/examples/aml_check.rb
@@ -2,7 +2,7 @@
 
 require 'smile-identity-core'
 require 'securerandom'
-# See https://docs.smileidentity.com/products/for-individuals-kyc/aml-check for
+# See https://docs.usesmileid.com/products/for-individuals-kyc/aml-check for
 # more information on business verification
 
 # Initialize

--- a/examples/biometric_kyc.rb
+++ b/examples/biometric_kyc.rb
@@ -2,7 +2,7 @@
 
 require 'smile-identity-core'
 
-# See https://docs.smileidentity.com/server-to-server/ruby/products/biometric-kyc for
+# See https://docs.usesmileid.com/server-to-server/ruby/products/biometric-kyc for
 # how to setup and retrieve configuation values for the WebApi class.
 
 # Initialize

--- a/examples/business_verification.rb
+++ b/examples/business_verification.rb
@@ -2,7 +2,7 @@
 
 require 'smile-identity-core'
 require 'securerandom'
-# See https://docs.smileidentity.com/products/for-businesses-kyb/business-verification for
+# See https://docs.usesmileid.com/products/for-businesses-kyb/business-verification for
 # more information on business verification
 
 # Initialize

--- a/examples/document_verification.rb
+++ b/examples/document_verification.rb
@@ -2,7 +2,7 @@
 
 require 'smile-identity-core'
 
-# See https://docs.smileidentity.com/server-to-server/ruby/products/document-verification for
+# See https://docs.usesmileid.com/server-to-server/ruby/products/document-verification for
 # how to setup and retrieve configuation values for the WebApi class.
 
 # Initialize

--- a/examples/enhanced_document_verification.rb
+++ b/examples/enhanced_document_verification.rb
@@ -2,7 +2,7 @@
 
 require 'smile-identity-core'
 
-# See https://docs.smileidentity.com/server-to-server/ruby/products/enhanced_document-verification for
+# See https://docs.usesmileid.com/server-to-server/ruby/products/enhanced_document-verification for
 # how to setup and retrieve configuation values for the WebApi class.
 
 # Initialize

--- a/examples/enhanced_kyc.rb
+++ b/examples/enhanced_kyc.rb
@@ -2,7 +2,7 @@
 
 require 'smile-identity-core'
 
-# See https://docs.smileidentity.com/server-to-server/ruby/products/enhanced-kyc for
+# See https://docs.usesmileid.com/server-to-server/ruby/products/enhanced-kyc for
 # how to setup and retrieve configuation values for the IDApi class.
 
 # Initialize

--- a/examples/example-project/README.md
+++ b/examples/example-project/README.md
@@ -1,6 +1,6 @@
 # Example Project
 
-This project is an example implementation of the Smile Identity Ruby SDK on the server side. The example implements [Enhanced KYC](https://docs.smileidentity.com/products/identity-lookup), [Biometric KYC](https://docs.smileidentity.com/products/biometric-kyc), [Document Verification](https://docs.smileidentity.com/products/document-verification) and [SmartSelfieTM Authentication](https://docs.smileidentity.com/products/biometric-authentication) job types.
+This project is an example implementation of the Smile Identity Ruby SDK on the server side. The example implements [Enhanced KYC](https://docs.usesmileid.com/products/identity-lookup), [Biometric KYC](https://docs.usesmileid.com/products/biometric-kyc), [Document Verification](https://docs.usesmileid.com/products/document-verification) and [SmartSelfieTM Authentication](https://docs.usesmileid.com/products/biometric-authentication) job types.
 
 ## Setup
 

--- a/examples/example-project/smart_bank.rb
+++ b/examples/example-project/smart_bank.rb
@@ -12,7 +12,7 @@ class SmartBank
   def initialize
     # login to the Smile Identity portal to view your partner id
     @partner_id = ENV['SMILE_PARTNER_ID']
-    # See https://docs.smileidentity.com/server-to-server/ruby/products/biometric-kyc#create-a-callback-endpoint
+    # See https://docs.usesmileid.com/server-to-server/ruby/products/biometric-kyc#create-a-callback-endpoint
     @default_callback = ENV['SMILE_JOB_CALLBACK_URL']
     @api_key = ENV['SMILE_API_KEY'] # copy your API key from the Smile Identity portal
     @sid_server = ENV['SMILE_SERVER_ENVIRONMENT'] # Use '0' for the sandbox server, use '1' for production server
@@ -187,7 +187,7 @@ enhanced_kyc_response['success'] # => true
 enhanced_kyc_response['result']['PartnerParams']['job_id'] # job_id
 enhanced_kyc_response['result']['PartnerParams']['user_id'] # user_id
 enhanced_kyc_response['result']['PartnerParams']['job_type'] # => 5
-# See https://docs.smileidentity.com/products/for-individuals-kyc/identity-lookup#return-values
+# See https://docs.usesmileid.com/products/for-individuals-kyc/identity-lookup#return-values
 # for the full JSON response interpretation
 
 # Biometric KYC
@@ -212,5 +212,5 @@ smart_selfie_auth_response['result']['PartnerParams']['user_id'] # user_id
 smart_selfie_auth_response['result']['PartnerParams']['job_type'] # => 2
 
 # All jobs submitted with a selfie has the same return values, result codes and texts. For example
-# see https://docs.smileidentity.com/products/for-individuals-kyc/biometric-kyc#return-values.
+# see https://docs.usesmileid.com/products/for-individuals-kyc/biometric-kyc#return-values.
 # Save the returned user_id and job_id in your DB as you would need them later when you call other services.

--- a/examples/get_web_token.rb
+++ b/examples/get_web_token.rb
@@ -3,7 +3,7 @@
 require 'smile-identity-core'
 require 'random/formatter'
 
-# See https://docs.smileidentity.com/server-to-server/ruby/products/biometric-kyc for
+# See https://docs.usesmileid.com/server-to-server/ruby/products/biometric-kyc for
 # how to setup and retrieve configuation values for the WebApi class.
 
 # Initialize

--- a/examples/smart_selfie_authentication.rb
+++ b/examples/smart_selfie_authentication.rb
@@ -2,7 +2,7 @@
 
 require 'smile-identity-core'
 
-# See https://docs.smileidentity.com/server-to-server/ruby/products/smartselfie-tm-authentication for
+# See https://docs.usesmileid.com/server-to-server/ruby/products/smartselfie-tm-authentication for
 # how to setup and retrieve configuation values for the WebApi class.
 
 # Initialize

--- a/lib/smile-identity-core/aml_check.rb
+++ b/lib/smile-identity-core/aml_check.rb
@@ -8,7 +8,7 @@ module SmileIdentityCore
   ##
   # The AML Check product allows you to perform due diligence on your customers by screening them against
   # global watchlists, politically exposed persons lists, and adverse media publications.
-  # For more info visit https://docs.smileidentity.com/products/for-individuals-kyc/aml-check
+  # For more info visit https://docs.usesmileid.com/products/for-individuals-kyc/aml-check
   class AmlCheck
     include Validations
 

--- a/lib/smile-identity-core/business_verification.rb
+++ b/lib/smile-identity-core/business_verification.rb
@@ -8,7 +8,7 @@ module SmileIdentityCore
   ##
   # The business verification product lets you search the business registration or
   # tax information (available in Nigeria only) of a business from one of our supported countries.
-  # For more info visit https://docs.smileidentity.com/products/for-businesses-kyb/business-verification
+  # For more info visit https://docs.usesmileid.com/products/for-businesses-kyb/business-verification
   class BusinessVerification
     include Validations
 

--- a/smile-identity-core.gemspec
+++ b/smile-identity-core.gemspec
@@ -8,18 +8,18 @@ Gem::Specification.new do |spec|
   spec.name          = 'smile-identity-core'
   spec.version       = SmileIdentityCore::VERSION
   spec.authors       = ['Smile Identity']
-  spec.email         = ['support@smileidentity.com']
+  spec.email         = ['support@usesmileid.com']
 
   spec.summary       = 'The Smile Identity Web API allows the user to access\
   most of the features of the Smile Identity system through direct server to server queries.'
   spec.description   = 'The Official Smile Identity gem'
-  spec.homepage      = 'https://www.smileidentity.com/'
+  spec.homepage      = 'https://www.usesmileid.com/'
   spec.required_ruby_version = '>= 2.5'
   spec.license = 'MIT'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/smileidentity/smile-identity-core-ruby'
-  spec.metadata['documentation_uri'] = 'https://docs.smileidentity.com'
+  spec.metadata['documentation_uri'] = 'https://docs.usesmileid.com'
   spec.metadata['changelog_uri'] = 'https://github.com/smileidentity/smile-identity-core-ruby/blob/master/CHANGELOG.md'
 
   # Specify which files should be added to the gem when it is released.

--- a/spec/smile-identity-core/business_verification_spec.rb
+++ b/spec/smile-identity-core/business_verification_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe SmileIdentityCore::BusinessVerification do
             'phone': '08000000000',
             'legal_name': 'SMILE IDENTITY NIGERIA LIMITED',
             'state': 'LAGOS',
-            'email': 'smile@smileidentity.com',
+            'email': 'smile@usesmileid.com',
             'status': 'ACTIVE'
           },
           'fiduciaries': [


### PR DESCRIPTION
This PR updates smileidentity.com to usesmileid.com as part of the gradual transition to using the new domain name throughout the system.