### PR TITLE
Potential fix for code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/lib/smile-identity-core/web_api.rb
+++ b/lib/smile-identity-core/web_api.rb
@@ -312,6 +312,7 @@ module SmileIdentityCore
     end
 
     def upload_file(url, info_json, smile_job_id)
+      validate_upload_url!(url)
       file = zip_up_file(info_json)
       file.rewind
 
@@ -334,6 +335,20 @@ module SmileIdentityCore
         return job_response
       end
       request.run
+    end
+
+    # Validate upload_url against expected host/prefix
+    def validate_upload_url!(upload_url)
+      allowed_host = URI.parse(@url).host
+      begin
+        uri = URI.parse(upload_url)
+      rescue URI::InvalidURIError
+        raise ArgumentError, "Invalid upload_url"
+      end
+      # Only allow URLs that match the known host
+      unless uri.host == allowed_host
+        raise ArgumentError, "Untrusted upload_url: #{upload_url}"
+      end
     end
 
     def query_job_status(counter = 0)


### PR DESCRIPTION
Potential fix for [https://github.com/smileidentity/smile-identity-core-ruby/security/code-scanning/5](https://github.com/smileidentity/smile-identity-core-ruby/security/code-scanning/5)

To address the SSRF vulnerability, we need to ensure that the `upload_url` used as an endpoint for the `PUT` request in `upload_file` is validated before use. Since `prep_upload_response['upload_url']` may come from an untrusted source, the safest approach is to check if it points to an expected host or matches a whitelist of base URLs before making any requests. Given the code context, you can enforce that all upload URLs must match a known host/domain—ideally the same as (or a subdomain of) what is expected for Smile Identity's servers (e.g., a prefix from `@url`). Implement a validation helper method that checks this, and reject nonconforming URLs by raising an error before the request is sent.

All changes need to be made within the actions surrounding the construction of the `url` variable and the call to `Typhoeus::Request`. Given the code blocks you have, this should be inside the `upload_file` method in lib/smile-identity-core/web_api.rb.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
