### PR TITLE
Add aliases support to AML Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.3.1] - 2026-04-24
+### Added
+- Support for optional `aliases` parameter in AML Check (`AmlCheck#submit_job`) to allow secondary names in screening requests
+
 ## [2.3.0] - 2024-12-10
 ### Added
 - Support for Address verification 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smile-identity-core (2.3.0)
+    smile-identity-core (2.3.1)
       rubyzip (~> 1.2, >= 1.2.3)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/examples/aml_check.rb
+++ b/examples/aml_check.rb
@@ -20,6 +20,7 @@ request_params = {
   birth_year: '1984', # yyyy
   search_existing_user: false,
   strict_match: true, # optional - default is true
+  # aliases: ['Johnny Doe', 'J. Doe'],  # optional - secondary names to broaden screening
 }
 
 # Submit the job

--- a/lib/smile-identity-core/aml_check.rb
+++ b/lib/smile-identity-core/aml_check.rb
@@ -35,6 +35,8 @@ module SmileIdentityCore
     # @option opts [boolean] :search_existing_user If you intend to re-use the name and year of birth
     # @option opts [boolean] :strict_match If you want to perform a strict match on the serach criteria.
     # of a user’s previous KYC job
+    # @option opts [Array<String>] :aliases An optional list of secondary or alternative names
+    #   (e.g. maiden names, transliterations, nicknames) to include in the screening search.
     # @option opts [Hash] :optional_info Any optional data, this will be returned
     # in partner_params.
     def submit_job(params)

--- a/lib/smile-identity-core/version.rb
+++ b/lib/smile-identity-core/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module SmileIdentityCore
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
   SOURCE_SDK = 'Ruby'
 end

--- a/spec/smile-identity-core/aml_check_spec.rb
+++ b/spec/smile-identity-core/aml_check_spec.rb
@@ -181,6 +181,22 @@ RSpec.describe SmileIdentityCore::AmlCheck do
           signature StrictMatch timestamp no_of_persons_found
         ])
       end
+
+    end
+
+    context 'when aliases are provided' do
+      before do
+        sent_body = nil
+        Typhoeus.stub('https://testapi.smileidentity.com/v1/aml') do |request|
+          @sent_body = JSON.parse(request.options[:body])
+          Typhoeus::Response.new(code: 200, body: aml_response)
+        end
+      end
+
+      it '#submit_job includes aliases in the request body' do
+        connection.submit_job(payload.merge(aliases: ['Johnny Doe', 'J. Doe']))
+        expect(@sent_body['aliases']).to eq(['Johnny Doe', 'J. Doe'])
+      end
     end
 
     describe '#build_payload' do
@@ -261,6 +277,25 @@ RSpec.describe SmileIdentityCore::AmlCheck do
         allow(connection).to receive(:generate_signature).and_return(signature)
         parsed_response = connection.send(:build_payload)
         expect(parsed_response[:strict_match]).to be true
+      end
+
+      it 'includes aliases in the payload when provided' do
+        payload[:aliases] = ['Johnny Doe', 'J. Doe']
+        connection.instance_variable_set(:@params, payload)
+
+        signature = { signature: Base64.strict_encode64('signature'), timestamp: Time.now.to_s }
+        allow(connection).to receive(:generate_signature).and_return(signature)
+        parsed_response = connection.send(:build_payload)
+        expect(parsed_response[:aliases]).to eq(['Johnny Doe', 'J. Doe'])
+      end
+
+      it 'does not include aliases in the payload when omitted' do
+        connection.instance_variable_set(:@params, payload)
+
+        signature = { signature: Base64.strict_encode64('signature'), timestamp: Time.now.to_s }
+        allow(connection).to receive(:generate_signature).and_return(signature)
+        parsed_response = connection.send(:build_payload)
+        expect(parsed_response).not_to have_key(:aliases)
       end
     end
 

--- a/spec/smile-identity-core/aml_check_spec.rb
+++ b/spec/smile-identity-core/aml_check_spec.rb
@@ -181,12 +181,10 @@ RSpec.describe SmileIdentityCore::AmlCheck do
           signature StrictMatch timestamp no_of_persons_found
         ])
       end
-
     end
 
     context 'when aliases are provided' do
       before do
-        sent_body = nil
         Typhoeus.stub('https://testapi.smileidentity.com/v1/aml') do |request|
           @sent_body = JSON.parse(request.options[:body])
           Typhoeus::Response.new(code: 200, body: aml_response)


### PR DESCRIPTION
### **User description**
- Documents aliases as an explicitly supported parameter in AmlCheck#submit_job via YARD docs — the field already passed through via the generic @payload.merge!(@params) pattern, but was undocumented
- Adds unit tests asserting aliases appears in build_payload output when provided, is absent when omitted, and is forwarded in the HTTP request body to /v1/aml
- Updates the example file with a commented-out aliases usage snippet
- Bumps version from 2.3.0 to 2.3.1 and adds a CHANGELOG entry


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Document and test `aliases` parameter for AML Check

- Add unit tests for aliases in payload and HTTP request

- Update example with commented-out aliases usage snippet

- Bump version from 2.3.0 to 2.3.1


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["aliases parameter"] -- "passed via" --> B["AmlCheck#submit_job"]
  B -- "merged into" --> C["build_payload"]
  C -- "sent in body" --> D["/v1/aml API"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aml_check.rb</strong><dd><code>Add aliases example snippet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/aml_check.rb

<ul><li>Added a commented-out <code>aliases</code> parameter example showing optional <br>secondary names usage</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-ruby/pull/82/files#diff-d2d2f492007a5f22a40a4b9c47dc66b4c45631aa096e3251e4bcd5f4e9fb330f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>aml_check.rb</strong><dd><code>Document aliases option in YARD docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/smile-identity-core/aml_check.rb

<ul><li>Added YARD documentation for the optional <code>aliases</code> parameter (<code>Array<String></code>) in <br><code>submit_job</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-ruby/pull/82/files#diff-6f5080d245880a41a8da34a20c3581a17845158e5610f85ae5e75319f95d8714">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for 2.3.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added <code>[2.3.1]</code> entry documenting support for optional <code>aliases</code> parameter <br>in AML Check</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-ruby/pull/82/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.rb</strong><dd><code>Bump version to 2.3.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/smile-identity-core/version.rb

- Bumped `VERSION` from `2.3.0` to `2.3.1`


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-ruby/pull/82/files#diff-623e615f781e9ec31b2586c6862984191ca60e8898a4e891e118dab386f21a61">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aml_check_spec.rb</strong><dd><code>Add aliases unit tests for AML Check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/smile-identity-core/aml_check_spec.rb

<ul><li>Added test verifying <code>aliases</code> is included in the HTTP request body when <br>provided<br> <li> Added test verifying <code>aliases</code> appears in <code>build_payload</code> output when <br>provided<br> <li> Added test verifying <code>aliases</code> is absent from <code>build_payload</code> when omitted</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-ruby/pull/82/files#diff-3b5a8bfae4a6c2ddeb8fafc325ee3f152ebf5c53459a128d75fe6ede442442cd">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>