### PR TITLE
fix(signature): use OpenSSL.fixed_length_secure_compare for constant time comparison

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw-ucrt
 
 DEPENDENCIES
   bundler (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,6 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw-ucrt
 
 DEPENDENCIES
   bundler (~> 2.0)

--- a/lib/smile-identity-core/signature.rb
+++ b/lib/smile-identity-core/signature.rb
@@ -25,7 +25,10 @@ module SmileIdentityCore
     # @param [String] msg_signature a previously generated signature, to be confirmed
     # @return [Boolean] TRUE or FALSE
     def confirm_signature(timestamp, msg_signature)
-      get_signature(timestamp)[:signature] == msg_signature
+      expected = get_signature(timestamp)[:signature]
+      return false unless expected.bytesize == msg_signature.bytesize
+
+      OpenSSL.fixed_length_secure_compare(expected, msg_signature)
     end
 
     private

--- a/spec/smile-identity-core/signature_spec.rb
+++ b/spec/smile-identity-core/signature_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+
 RSpec.describe SmileIdentityCore::Signature do
   let(:partner_id) { '001' }
   let(:rsa) { OpenSSL::PKey::RSA.new(1024) }
@@ -69,6 +71,12 @@ RSpec.describe SmileIdentityCore::Signature do
       hmac.update('sid_request')
       signature = Base64.strict_encode64(hmac.digest)
       expect(connection.confirm_signature(timestamp, signature)).to be(true)
+    end
+
+    it 'rejects a signature that does not match' do
+      timestamp = Time.now.to_s
+      fake_signature = Base64.strict_encode64(SecureRandom.random_bytes(32))
+      expect(connection.confirm_signature(timestamp, fake_signature)).to be(false)
     end
   end
 end


### PR DESCRIPTION
### **User description**
This pull request enhances the security of the signature confirmation process and improves test coverage for the `SmileIdentityCore::Signature` class. The key changes are grouped below:

**Security improvements:**

* Updated the `confirm_signature` method in `signature.rb` to use `OpenSSL.fixed_length_secure_compare` for signature comparison, protecting against timing attacks. The method now also checks that the expected and provided signatures are the same length before comparing.

**Testing improvements:**

* Added a test in `signature_spec.rb` to verify that an invalid signature is correctly rejected by `confirm_signature`.
* Added a `require 'securerandom'` statement to support generation of random bytes for test signatures.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Use constant-time comparison for signature verification

- Add length check before secure comparison

- Add test for invalid signature rejection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["confirm_signature method"] -- "previously" --> B["direct == comparison"]
  A -- "now" --> C["bytesize check"]
  C -- "same length" --> D["OpenSSL.fixed_length_secure_compare"]
  C -- "different length" --> E["return false"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signature.rb</strong><dd><code>Constant-time signature comparison to prevent timing attacks</code></dd></summary>
<hr>

lib/smile-identity-core/signature.rb

<ul><li>Replaced direct string equality (<code>==</code>) with <br><code>OpenSSL.fixed_length_secure_compare</code> for constant-time signature <br>comparison<br> <li> Added a bytesize check to return false early if lengths differ</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-ruby/pull/88/files#diff-46a0809455df1f7e4b7fb871937bd4115f86ef2402a344bb7af6e498273649b6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signature_spec.rb</strong><dd><code>Add test for invalid signature rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/smile-identity-core/signature_spec.rb

<ul><li>Added <code>require 'securerandom'</code> for generating random bytes<br> <li> Added test case verifying that an invalid/fake signature is rejected</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-ruby/pull/88/files#diff-10a51087767aa921e63be49b30463abefe54e8f57dc5c7bc1a6f483cf01074af">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>