### PR TITLE
Add DefectDojo import step to Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,6 +32,31 @@ jobs:
         with:
           sarif_file: semgrep.sarif
 
+      - name: Import results into DefectDojo
+        if: always()
+        continue-on-error: true
+        env:
+          DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
+          DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+        run: |
+          if [ ! -s semgrep.sarif ]; then
+            echo "No semgrep.sarif file found, skipping DefectDojo import"
+            exit 0
+          fi
+          curl -sS -f \
+            -H "Authorization: Token ${DEFECTDOJO_API_TOKEN}" \
+            -F "scan_type=SARIF" \
+            -F "file=@semgrep.sarif" \
+            -F "product_type_name=GitHub" \
+            -F "product_name=${{ github.event.repository.name }}" \
+            -F "engagement_name=CI" \
+            -F "auto_create_context=true" \
+            -F "close_old_findings=true" \
+            -F "deduplication_on_engagement=true" \
+            -F "commit_hash=${{ github.sha }}" \
+            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
+
       - name: Comment findings on PR
         if: github.event_name == 'pull_request' && always()
         env:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,6 +38,8 @@ jobs:
         env:
           DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
           DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_TAG: ${{ github.head_ref || github.ref_name }}
         run: |
           if [ ! -s semgrep.sarif ]; then
             echo "No semgrep.sarif file found, skipping DefectDojo import"
@@ -48,13 +50,13 @@ jobs:
             -F "scan_type=SARIF" \
             -F "file=@semgrep.sarif" \
             -F "product_type_name=GitHub" \
-            -F "product_name=${{ github.event.repository.name }}" \
+            -F "product_name=${REPO_NAME}" \
             -F "engagement_name=CI" \
             -F "auto_create_context=true" \
             -F "close_old_findings=true" \
             -F "deduplication_on_engagement=true" \
             -F "commit_hash=${{ github.sha }}" \
-            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            -F "branch_tag=${BRANCH_TAG}" \
             "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
 
       - name: Comment findings on PR


### PR DESCRIPTION
### **User description**
## Summary
- Adds an "Import results into DefectDojo" step to `.github/workflows/semgrep.yml`, run after the existing "Upload SARIF to GitHub Security" step.
- Non-blocking (`if: always()`, `continue-on-error: true`): skips gracefully if `semgrep.sarif` is missing/empty, otherwise POSTs it to DefectDojo's `reimport-scan` API using the org-wide `DEFECTDOJO_URL` / `DEFECTDOJO_API_TOKEN` secrets (already scoped to this repo).
- Mirrors the same change proposed in `smileidentity/lambda#4662` (currently open, not yet merged, but its own pull_request-triggered CI run proved the step works).
- SARIF filename in this repo: this workflow's `Run Semgrep` step runs `semgrep scan --config p/security-audit --sarif -o semgrep.sarif`, so it writes to `semgrep.sarif` — same filename as the lambda template, no path adjustment needed. Reviewer: please double check this still matches if the Semgrep step changes in the future.

## Test plan
- [ ] Confirm the workflow runs successfully on this PR's own `pull_request` CI trigger (Semgrep job should complete, and the new DefectDojo step should either import successfully or skip/soft-fail without blocking the job).
- [ ] Spot-check in DefectDojo (https://defectdojo.smile.id) that a new/updated scan shows up for this repo under a "GitHub" product / this repo's product name once the workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add DefectDojo SARIF import step to Semgrep CI workflow

- Uses reimport-scan API with auto-created context

- Non-blocking step with graceful skip if SARIF missing

- Sends commit hash and branch metadata to DefectDojo


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Semgrep Scan"] -- "generates" --> B["semgrep.sarif"]
  B -- "upload" --> C["GitHub Code Scanning"]
  B -- "reimport-scan API" --> D["DefectDojo"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Add DefectDojo reimport-scan step to Semgrep job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>Added a new "Import results into DefectDojo" step after the GitHub <br>SARIF upload<br> <li> Step checks if <code>semgrep.sarif</code> exists and is non-empty before proceeding<br> <li> Uses <code>curl</code> to POST the SARIF file to DefectDojo's <code>reimport-scan</code> API <br>endpoint<br> <li> Configured with <code>if: always()</code> and <code>continue-on-error: true</code> to be <br>non-blocking<br> <li> Passes repository name, commit hash, and branch as metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-ruby/pull/91/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>